### PR TITLE
Allow wildcard fallback

### DIFF
--- a/lib/exdns/config.ex
+++ b/lib/exdns/config.ex
@@ -15,4 +15,6 @@ defmodule Exdns.Config do
 
   def servers, do: Application.get_env(:exdns, :servers, [])
 
+  def wildcard_fallback, do: Application.get_env(:exdns, :wildcard_fallback, false)
+
 end

--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -1664,6 +1664,33 @@
           }
         }
       ]
+    },
+    {
+      "name": "*",
+      "records": [
+      {
+        "name": "*",
+        "type": "SOA",
+        "data": {
+          "mname": "ns1.example.com",
+          "rname": "ahu.example.com",
+          "serial": 2000081501,
+          "refresh": 28800,
+          "retry": 7200,
+          "expire": 604800,
+          "minimum": 86400
+        },
+        "ttl": 100000
+      },
+      {
+        "name": "*",
+        "type": "A",
+        "ttl": 120,
+        "data": {
+          "ip": "1.2.3.4"
+        }
+      }
+      ]
     }
 ]
 

--- a/test/exdns/zone/cache_test.exs
+++ b/test/exdns/zone/cache_test.exs
@@ -71,8 +71,12 @@ defmodule Exdns.Zone.CacheTest do
     assert Exdns.Zone.Cache.find_zone_in_cache("notfound.com") == {:error, :zone_not_found}
   end
 
-
   test "normalize name" do
     assert Exdns.Zone.Cache.normalize_name("eXaMpLe.CoM") == "example.com"
+  end
+
+  test "fallback to wildcard zone when configured" do
+    Application.put_env(:exdns, :wildcard_fallback, true)
+    {:ok, _zone} = Exdns.Zone.Cache.find_zone_in_cache("notfound.com")
   end
 end


### PR DESCRIPTION
### Context

As discussed in #1, some nameservers use case involve returning a generic answer for any domain (e.g. parking pages).

This is currently not possible with exdns.

### Proposed solution

- Allow fallback to be enabled through configuration (disabled by default)
- Allow zone cache to fallback to configured wildcard zone ("*") if it exists and if the fallback is enabled