### PR TITLE
Fix compile warnings

### DIFF
--- a/lib/exdns/encoder.ex
+++ b/lib/exdns/encoder.ex
@@ -33,5 +33,5 @@ defmodule Exdns.Encoder do
 
   defp build_error_message({_, message}), do: build_error_message(message, :dns_term_const.dns_rcode_servfail)
   defp build_error_message(message), do: build_error_message(message, :dns_term_const.dns_rcode_servfail)
-  defp build_error_message(message, rcode), do: Exdns.Records.dns_message(rc: rcode)
+  defp build_error_message(_message, rcode), do: Exdns.Records.dns_message(rc: rcode)
 end

--- a/lib/exdns/encoder.ex
+++ b/lib/exdns/encoder.ex
@@ -31,7 +31,7 @@ defmodule Exdns.Encoder do
 
   # Private functions
 
-  defp build_error_message({_, message}), do: build_error_message(message, :dns_term_const.dns_rcode_servfail)
-  defp build_error_message(message), do: build_error_message(message, :dns_term_const.dns_rcode_servfail)
+  defp build_error_message({_, message}), do: build_error_message(message, :dns_terms_const.dns_rcode_servfail)
+  defp build_error_message(message), do: build_error_message(message, :dns_terms_const.dns_rcode_servfail)
   defp build_error_message(_message, rcode), do: Exdns.Records.dns_message(rc: rcode)
 end

--- a/lib/exdns/handler.ex
+++ b/lib/exdns/handler.ex
@@ -15,7 +15,7 @@ defmodule Exdns.Handler do
   def handle(message, context = {_, host}) when Record.is_record(message, :dns_message) do
     handle(message, host, Exdns.QueryThrottle.throttle(message, context))
   end
-  def handle(bad_message, {_, host}) do
+  def handle(bad_message, {_, _host}) do
     bad_message
   end
 
@@ -69,7 +69,7 @@ defmodule Exdns.Handler do
         message = Exdns.Resolver.resolve(message, authority, host)
         maybe_cache_packet(message, Exdns.Records.dns_message(message, :aa))
       rescue
-        exception ->
+        _exception ->
           # Logger.error("Error answering request: #{inspect exception}")
           Exdns.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_servfail)
       end

--- a/lib/exdns/handler/registry.ex
+++ b/lib/exdns/handler/registry.ex
@@ -35,7 +35,7 @@ defmodule Exdns.Handler.Registry do
     {:reply, handlers, handlers}
   end
 
-  def handle_call(:clear, _, handlers) do
+  def handle_call(:clear, _, _handlers) do
     {:reply, :ok, []}
   end
 end

--- a/lib/exdns/resolver.ex
+++ b/lib/exdns/resolver.ex
@@ -140,12 +140,12 @@ defmodule Exdns.Resolver do
 
 
   # We are authoritative and there are no NS records here
-  def resolve_exact_type_match(message, qname, qtype, host, cname_chain, matched_records, zone, authority_records, []) do
+  def resolve_exact_type_match(message, _qname, _qtype, _host, _cname_chain, matched_records, _zone, _authority_records, []) do
     Logger.debug("Resolved exact type match and there are no NS records: #{inspect matched_records}")
     Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: merge_with_answers(message, matched_records))
   end
   # We are authoritative and there are NS records here
-  def resolve_exact_type_match(message, qname, qtype, host, cname_chain, matched_records, zone, authority_records, ns_records) do
+  def resolve_exact_type_match(message, _qname, qtype, host, cname_chain, matched_records, zone, _authority_records, ns_records) do
     Logger.debug("Resolved exact type match and there are NS records")
     # NOTE: there is a potential bug here because it assumes the last record is the one to examine
     answer = List.last(matched_records)
@@ -174,7 +174,7 @@ defmodule Exdns.Resolver do
   end
 
 
-  def resolve_no_exact_type_match(message, qtype, host, cname_chain, exact_type_matches, zone, matched_records, referral_records, authority_records) do
+  def resolve_no_exact_type_match(message, qtype, _host, _cname_chain, exact_type_matches, zone, matched_records, referral_records, authority_records) do
     any_type = :dns_terms_const.dns_type_any
     case qtype do
       ^any_type -> Exdns.Records.dns_message(message, aa: true, authority: authority_records)
@@ -190,7 +190,7 @@ defmodule Exdns.Resolver do
 
   # Given an exact name match where the qtype is not found in the record set, and we are not authoritative,
   # add the NS records to the authority section of the message.
-  def resolve_exact_match_referral(message, qtype, matched_records, referral_records, []) do
+  def resolve_exact_match_referral(message, _qtype, _matched_records, referral_records, []) do
     Exdns.Records.dns_message(message, authority: merge_with_authority(message, referral_records))
   end
   def resolve_exact_match_referral(message, qtype, matched_records, referral_records, authority_records) do
@@ -207,7 +207,7 @@ defmodule Exdns.Resolver do
   end
 
 
-  def resolve_exact_match_with_cname(message, qtype, host, cname_chain, matched_records, zone, cname_records) do
+  def resolve_exact_match_with_cname(message, qtype, host, cname_chain, _matched_records, zone, cname_records) do
     cname_type = :dns_terms_const.dns_type_cname
     case qtype do
       ^cname_type ->
@@ -312,15 +312,15 @@ defmodule Exdns.Resolver do
         resolve_best_match_with_wildcard_cname(message, qname, qtype, host, cname_chain, matched_records, zone, cname_records)
     end
   end
-  def resolve_best_match_with_wildcard(message, qname, qtype, host, cname_chain, best_match_records, zone, [], []) do
+  def resolve_best_match_with_wildcard(message, _qname, _qtype, _host, _cname_chain, _best_match_records, zone, [], []) do
     Exdns.Records.dns_message(message, aa: true, authority: [zone.authority])
   end
-  def resolve_best_match_with_wildcard(message, qname, qtype, host, cname_chain, best_match_records, zone, [], type_matches) do
+  def resolve_best_match_with_wildcard(message, _qname, _qtype, _host, _cname_chain, _best_match_records, _zone, [], type_matches) do
     Exdns.Records.dns_message(message, aa: true, answers: merge_with_answers(message, type_matches))
   end
 
 
-  def resolve_best_match_with_wildcard_cname(message, qname, qtype, host, cname_chain, best_match_records, zone, cname_records) do
+  def resolve_best_match_with_wildcard_cname(message, _qname, qtype, host, cname_chain, _best_match_records, zone, cname_records) do
     cname_type = :dns_terms_const.dns_type_cname
     case qtype do
       ^cname_type ->
@@ -343,7 +343,7 @@ defmodule Exdns.Resolver do
   #
   # If there are no SOA records present then we indicate we are not authoritivate for the name.
   # If there is an SOA record then we authoritative for the name
-  def resolve_best_match_referral(message, qname, qtype, host, cname_chain, best_match_records, zone, referral_records) do
+  def resolve_best_match_referral(message, _qname, qtype, _host, cname_chain, best_match_records, _zone, referral_records) do
     authority = Enum.filter(best_match_records, Exdns.Records.match_type(:dns_terms_const.dns_type_soa))
     any_type = :dns_terms_const.dns_type_any
     case {qtype, cname_chain, authority} do
@@ -413,7 +413,7 @@ defmodule Exdns.Resolver do
 
 
   def additional_processing(message, _host, {:error, _}), do: message
-  def additional_processing(message, host, zone) do
+  def additional_processing(message, _host, _zone) do
     record_names = merge_with_answers(message, Exdns.Records.dns_message(message, :authority)) |> requires_additional_processing([]) |> List.flatten
     case record_names do
       [] -> message

--- a/lib/exdns/resolver.ex
+++ b/lib/exdns/resolver.ex
@@ -383,7 +383,7 @@ defmodule Exdns.Resolver do
 
   def custom_lookup(qname, qtype, records) do
     fn({module, types}) ->
-      if Lists.member?(types, qtype) || qtype == :dns_terms_const.dns_type_any  do
+      if Enum.member?(types, qtype) || qtype == :dns_terms_const.dns_type_any  do
         module.handle(qname, qtype, records)
       else
         []

--- a/lib/exdns/server/tcp_server.ex
+++ b/lib/exdns/server/tcp_server.ex
@@ -6,12 +6,12 @@ defmodule Exdns.Server.TcpServer do
 
   require Logger
 
-  def start_link(name, inet_family, address, port) do
+  def start_link(_name, inet_family, address, port) do
     Logger.debug("Starting TCP server for #{inet_family} on address #{inspect address} port #{port}")
     :gen_nb_server.start_link(__MODULE__, address, port, [])
   end
 
-  def stop(name) do
+  def stop(_name) do
 
   end
 
@@ -29,8 +29,8 @@ defmodule Exdns.Server.TcpServer do
     {:noreply, state}
   end
 
-  def handle_info(msg = {:tcp, socket, bin}, state) do
-    response = :folsom_metrics.histogram_timed_update(:tcp_handoff_histogram, Exdns.Server.TcpServer, :handle_request, [socket, bin, state])
+  def handle_info(_msg = {:tcp, socket, bin}, state) do
+    _response = :folsom_metrics.histogram_timed_update(:tcp_handoff_histogram, Exdns.Server.TcpServer, :handle_request, [socket, bin, state])
     :inet.setopts(socket, [{:active, :once}])
     {:noreply, state}
   end
@@ -39,7 +39,7 @@ defmodule Exdns.Server.TcpServer do
     {:noreply, state}
   end
 
-  def terminate(_reason, state) do
+  def terminate(_reason, _state) do
     :ok
   end
 

--- a/lib/exdns/worker.ex
+++ b/lib/exdns/worker.ex
@@ -70,7 +70,7 @@ defmodule Exdns.Worker do
     end
   end
 
-  def handle_tcp_dns_query(socket, bad_packet) do
+  def handle_tcp_dns_query(socket, _bad_packet) do
     :gen_tcp.close(socket)
   end
 

--- a/lib/exdns/zone/parser.ex
+++ b/lib/exdns/zone/parser.ex
@@ -44,7 +44,7 @@ defmodule Exdns.Zone.Parser do
   def apply_context_options(_record = %{"context" => context}) do
     case Application.get_env(:exdns, :context_options) do
       {:ok, _context_options} ->
-        context_set = Set.from_list(context)
+        context_set = MapSet.new(context)
         result = [] # TODO implement
         if Enum.any?(result, fn(i) -> i == :pass end) do
           :pass

--- a/lib/exdns/zone/parser.ex
+++ b/lib/exdns/zone/parser.ex
@@ -22,7 +22,7 @@ defmodule Exdns.Zone.Parser do
       case apply_context_options(r) do
         :pass ->
           case json_record_to_rr(r) do
-            {} -> try_custom_parsers(r, Exdns.Zone.Parser.Registry.get_all)
+            {} -> try_custom_parsers(r, Exdns.Zone.Registry.get_all)
             record -> record
           end
         _ ->

--- a/lib/exdns/zone/parser.ex
+++ b/lib/exdns/zone/parser.ex
@@ -41,9 +41,9 @@ defmodule Exdns.Zone.Parser do
     }
   end
 
-  def apply_context_options(record = %{"context" => context}) do
+  def apply_context_options(_record = %{"context" => context}) do
     case Application.get_env(:exdns, :context_options) do
-      {:ok, context_options} ->
+      {:ok, _context_options} ->
         context_set = Set.from_list(context)
         result = [] # TODO implement
         if Enum.any?(result, fn(i) -> i == :pass end) do
@@ -57,7 +57,7 @@ defmodule Exdns.Zone.Parser do
   end
   def apply_context_options(_), do: :pass
 
-  def try_custom_parsers(record, []), do: {}
+  def try_custom_parsers(_record, []), do: {}
   def try_custom_parsers(record, [parser|rest]) do
     case parser.json_record_to_rr(record) do
       {} -> try_custom_parsers(record, rest)

--- a/lib/exdns/zone/registry.ex
+++ b/lib/exdns/zone/registry.ex
@@ -35,7 +35,7 @@ defmodule Exdns.Zone.Registry do
     {:reply, items, items}
   end
 
-  def handle_call(:clear, _, items) do
+  def handle_call(:clear, _, _items) do
     {:reply, :ok, []}
   end
 end


### PR DESCRIPTION
I get several warning during compilation with Elixir 1.3.2. Most of them are unused variables or typos.
### Changes
- Prefix unused variables with `_`. Some of them could be removed entirely but kept them with a prefix for context.
- Fix obvious typos.
- Replace deprecated modules/functions.
### Notes
- I assumed `Lists.member?/2` was supposed to be `Enum.member?`
- I couldn't find anything about `Set.from_list/2`. I replaced it with `MapSet.new/2` but that's only a guess.
- There seem to be missing tests around the code from the last 3 commits. I'm lacking too much understanding of the codebase to be able to add them myself.

Hope this helps! Cheers
