### PR TITLE
Proper capitalisation for acronyms and ExDNS, Mixfile update and Supervisor syntax update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: elixir
 elixir:
-  - 1.3
+  - 1.6

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Exdns
+# ExDNS
 
 [![Build Status](https://api.travis-ci.org/dnsimple/exdns.svg?branch=master)](https://travis-ci.org/dnsimple/exdns/)
 
@@ -33,9 +33,9 @@ and add one or more servers to it.
 
 ```
 config :exdns, servers: [
-  %{name: :udp_inet_localhost_1, type: Exdns.Server.UdpServer, address: "127.0.0.1", port: 8053, family: :inet},
-  %{name: :udp_inet6_localhost_1, type: Exdns.Server.UdpServer, address: "::1", port: 8053, family: :inet6},
-  %{name: :tcp_inet_localhost_1, type: Exdns.Server.TcpServer, address: "127.0.0.1", port: 8053, family: :inet},
-  %{name: :tcp_inet6_localhost_1, type: Exdns.Server.TcpServer, address: "::1", port: 8053, family: :inet6}
+  %{name: :udp_inet_localhost_1, type: ExDNS.Server.UDPServer, address: "127.0.0.1", port: 8053, family: :inet},
+  %{name: :udp_inet6_localhost_1, type: ExDNS.Server.UDPServer, address: "::1", port: 8053, family: :inet6},
+  %{name: :tcp_inet_localhost_1, type: ExDNS.Server.TCPServer, address: "127.0.0.1", port: 8053, family: :inet},
+  %{name: :tcp_inet6_localhost_1, type: ExDNS.Server.TCPServer, address: "::1", port: 8053, family: :inet6}
 ]
 ```

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,8 +4,8 @@ config :exdns, catch_exceptions: false
 config :exdns, zone_file: "priv/test.zones.json"
 
 config :exdns, servers: [
-  %{name: :udp_inet_localhost_1, type: Exdns.Server.UdpServer, address: "127.0.0.1", port: 8053, family: :inet},
-  %{name: :udp_inet6_localhost_1, type: Exdns.Server.UdpServer, address: "::1", port: 8053, family: :inet6},
-  %{name: :tcp_inet_localhost_1, type: Exdns.Server.TcpServer, address: "127.0.0.1", port: 8053, family: :inet},
-  %{name: :tcp_inet6_localhost_1, type: Exdns.Server.TcpServer, address: "::1", port: 8053, family: :inet6}
+  %{name: :udp_inet_localhost_1, type: ExDNS.Server.UDPServer, address: "127.0.0.1", port: 8053, family: :inet},
+  %{name: :udp_inet6_localhost_1, type: ExDNS.Server.UDPServer, address: "::1", port: 8053, family: :inet6},
+  %{name: :tcp_inet_localhost_1, type: ExDNS.Server.TCPServer, address: "127.0.0.1", port: 8053, family: :inet},
+  %{name: :tcp_inet6_localhost_1, type: ExDNS.Server.TCPServer, address: "::1", port: 8053, family: :inet6}
 ]

--- a/lib/exdns.ex
+++ b/lib/exdns.ex
@@ -1,60 +1,11 @@
-defmodule Exdns do
+defmodule ExDNS do
   @moduledoc """
-  exdns is a port of the erldns authoritative name server written in Elixir.
+  Documentation for ExDNS.
   """
-
-  require Logger
-
-  def start(_type, _args) do
-    setup_metrics()
-    Exdns.Supervisor.start_link()
-  end
-
-  def start_phase(:post_start, _start_type, _phase_args) do
-    Exdns.Events.add_handler(Exdns.Events, [])
-    Exdns.Zone.Loader.load_zones()
-    Exdns.Events.notify(:start_servers)
-
-    :ok
-  end
 
   def timestamp() do
     {tm, ts, _} = :os.timestamp()
     (tm * 1000000) + ts
   end
-
-  defp setup_metrics() do
-    :folsom_metrics.new_counter(:udp_request_counter)
-    :folsom_metrics.new_counter(:tcp_request_counter)
-    :folsom_metrics.new_meter(:udp_request_meter)
-    :folsom_metrics.new_meter(:tcp_request_meter)
-
-    :folsom_metrics.new_meter(:udp_error_meter)
-    :folsom_metrics.new_meter(:tcp_error_meter)
-    :folsom_metrics.new_history(:udp_error_history)
-    :folsom_metrics.new_history(:tcp_error_history)
-
-    :folsom_metrics.new_meter(:refused_response_meter)
-    :folsom_metrics.new_counter(:refused_response_counter)
-
-    :folsom_metrics.new_meter(:empty_response_meter)
-    :folsom_metrics.new_counter(:empty_response_counter)
-
-    :folsom_metrics.new_histogram(:udp_handoff_histogram)
-    :folsom_metrics.new_histogram(:tcp_handoff_histogram)
-
-    :folsom_metrics.new_counter(:request_throttled_counter)
-    :folsom_metrics.new_meter(:request_throttled_meter)
-    :folsom_metrics.new_histogram(:request_handled_histogram)
-
-    :folsom_metrics.new_counter(:packet_dropped_empty_queue_counter)
-    :folsom_metrics.new_meter(:packet_dropped_empty_queue_meter)
-
-    :folsom_metrics.new_meter(:cache_hit_meter)
-    :folsom_metrics.new_meter(:cache_expired_meter)
-    :folsom_metrics.new_meter(:cache_miss_meter)
-
-    :folsom_metrics.new_counter(:dnssec_request_counter)
-    :folsom_metrics.new_meter(:dnssec_request_meter)
-  end
 end
+

--- a/lib/exdns/application.ex
+++ b/lib/exdns/application.ex
@@ -1,0 +1,61 @@
+ defmodule ExDNS.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+  require Logger
+
+  def start(_type, _args) do
+    setup_metrics()
+    # List all child processes to be supervised
+    children = [
+      ExDNS.Events,
+      ExDNS.Handler.Registry,
+      ExDNS.PacketCache,
+      ExDNS.QueryThrottle,
+      ExDNS.Zone.Cache,
+      ExDNS.Zone.Registry,
+      # ExDNS.ZoneEncoder,
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: ExDNS.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def start_phase(:post_start, _start_type, _phase_args) do
+    ExDNS.Zone.Loader.load_zones()
+    ExDNS.Events.notify(:start_servers)
+    :ok
+  end
+
+  defp setup_metrics() do
+    :folsom_metrics.new_counter(:udp_request_counter)
+    :folsom_metrics.new_counter(:tcp_request_counter)
+    :folsom_metrics.new_meter(:udp_request_meter)
+    :folsom_metrics.new_meter(:tcp_request_meter)
+    :folsom_metrics.new_meter(:udp_error_meter)
+    :folsom_metrics.new_meter(:tcp_error_meter)
+    :folsom_metrics.new_history(:udp_error_history)
+    :folsom_metrics.new_history(:tcp_error_history)
+    :folsom_metrics.new_meter(:refused_response_meter)
+    :folsom_metrics.new_counter(:refused_response_counter)
+    :folsom_metrics.new_meter(:empty_response_meter)
+    :folsom_metrics.new_counter(:empty_response_counter)
+    :folsom_metrics.new_histogram(:udp_handoff_histogram)
+    :folsom_metrics.new_histogram(:tcp_handoff_histogram)
+    :folsom_metrics.new_counter(:request_throttled_counter)
+    :folsom_metrics.new_meter(:request_throttled_meter)
+    :folsom_metrics.new_histogram(:request_handled_histogram)
+    :folsom_metrics.new_counter(:packet_dropped_empty_queue_counter)
+    :folsom_metrics.new_meter(:packet_dropped_empty_queue_meter)
+    :folsom_metrics.new_meter(:cache_hit_meter)
+    :folsom_metrics.new_meter(:cache_expired_meter)
+    :folsom_metrics.new_meter(:cache_miss_meter)
+
+    :folsom_metrics.new_counter(:dnssec_request_counter)
+    :folsom_metrics.new_meter(:dnssec_request_meter)
+  end
+end

--- a/lib/exdns/config.ex
+++ b/lib/exdns/config.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Config do
+defmodule ExDNS.Config do
   @moduledoc """
   Configuration details for exdns.
   """
@@ -9,7 +9,7 @@ defmodule Exdns.Config do
 
   def zone_file, do: Application.get_env(:exdns, :zone_file, "zones.json")
 
-  def storage_type, do: Application.get_env(:exdns, :storage_type, Exdns.Storage.EtsStorage)
+  def storage_type, do: Application.get_env(:exdns, :storage_type, ExDNS.Storage.EtsStorage)
 
   def num_workers, do: Application.get_env(:exdns, :num_workers, 16)
 

--- a/lib/exdns/decoder.ex
+++ b/lib/exdns/decoder.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Decoder do
+defmodule ExDNS.Decoder do
   @moduledoc """
   Functions used to decode DNS messages safely.
   """
@@ -7,7 +7,7 @@ defmodule Exdns.Decoder do
 
   @spec decode_message(:dns.message_bin()) :: {:dns.decode_error(), :dns.message() | :undefined, binary()} | :dns.message()
   def decode_message(bin) do
-    if Exdns.Config.catch_exceptions? do
+    if ExDNS.Config.catch_exceptions? do
       try do
         :dns.decode_message(bin)
       catch

--- a/lib/exdns/edns.ex
+++ b/lib/exdns/edns.ex
@@ -1,12 +1,12 @@
-defmodule Exdns.Edns do
+defmodule ExDNS.Edns do
   @moduledoc """
   EDNS0 support (extensions for DNS)
   """
 
   require Record
-  require Exdns.Records
+  require ExDNS.Records
 
-  def get_opts(message), do: get_opts(Exdns.Records.dns_message(message, :additional), [])
+  def get_opts(message), do: get_opts(ExDNS.Records.dns_message(message, :additional), [])
 
   def get_opts([], opts), do: opts
   def get_opts([rr|rest], opts) do
@@ -14,7 +14,7 @@ defmodule Exdns.Edns do
       ^rr when Record.is_record(rr, :dns_rr) ->
         get_opts(rest, opts)
       ^rr when Record.is_record(rr, :dns_optrr) ->
-        if Exdns.Records.dns_optrr(rr, :dnssec) do
+        if ExDNS.Records.dns_optrr(rr, :dnssec) do
           get_opts(rest, opts ++ [{:dnssec, true}])
         else
           get_opts(rest, opts)

--- a/lib/exdns/encoder.ex
+++ b/lib/exdns/encoder.ex
@@ -1,10 +1,10 @@
-defmodule Exdns.Encoder do
+defmodule ExDNS.Encoder do
   @moduledoc """
   Functions for encoding DNS messages to binary representations safely.
   """
 
   require Logger
-  require Exdns.Records
+  require ExDNS.Records
 
   def encode_message(message) do
     encode_message(message, [])
@@ -16,7 +16,7 @@ defmodule Exdns.Encoder do
     {false, :dns.message_bin(), :dns.tsig_mac()} |
     {true, :dns.message_bin(), :dns.tsig_mac(), :dns.message()}
   def encode_message(message, opts) do
-    if Exdns.Config.catch_exceptions? do
+    if ExDNS.Config.catch_exceptions? do
       try do
         :dns.encode_message(message, opts)
       catch
@@ -33,5 +33,5 @@ defmodule Exdns.Encoder do
 
   defp build_error_message({_, message}), do: build_error_message(message, :dns_terms_const.dns_rcode_servfail)
   defp build_error_message(message), do: build_error_message(message, :dns_terms_const.dns_rcode_servfail)
-  defp build_error_message(_message, rcode), do: Exdns.Records.dns_message(rc: rcode)
+  defp build_error_message(_message, rcode), do: ExDNS.Records.dns_message(rc: rcode)
 end

--- a/lib/exdns/events.ex
+++ b/lib/exdns/events.ex
@@ -2,91 +2,106 @@ defmodule ExDNS.Events do
   @moduledoc """
   Event manager for events fired by exdns.
   """
-
-  use GenServer
+ 
+  use GenEvent
   require Logger
-
+ 
   # Public API
-
+ 
   def start_link([]) do
     GenEvent.start_link(name: ExDNS.Events)
   end
-
+ 
   def notify(message) do
     GenEvent.notify(ExDNS.Events, message)
   end
-
+ 
+  def add_handler(module, args) do
+    GenEvent.add_handler(ExDNS.Events, module, args)
+  end
+ 
   # GenEvent callbacks
   def init(_) do
-    {:noreply, %{:servers_running => false}}
+    {:ok, %{:servers_running => false}}
   end
-
+ 
   def handle_call(:get_servers_running, state) do
-    {:noreply, Map.get(state, :servers_running), state}
+    {:ok, Map.get(state, :servers_running), state}
   end
 
-  # Event handlers
+    def child_spec(opts) do
+      %{
+        id: __MODULE__,
+        start: {__MODULE__, :start_link, [opts]},
+        type: :worker,
+        restart: :permanent,
+        shutdown: 500
+      }
+    end
 
-  def handle_cast(:start_servers, state) do
+ 
+  # Event handlers
+ 
+  def handle_event(:start_servers, state) do
     if Map.get(state, :servers_running) do
       ExDNS.Events.notify(:servers_already_started)
-      {:noreply, state}
+      {:ok, state}
     else
       ExDNS.Server.Supervisor.start_link([])
       ExDNS.Events.notify(:servers_started)
-      {:noreply, %{state | servers_running: true}}
+      {:ok, %{state | servers_running: true}}
     end
   end
-
-  def handle_cast(:stop_servers, state) do
-    {:noreply, %{state | servers_running: false}}
+ 
+  def handle_event(:stop_servers, state) do
+    {:ok, %{state | servers_running: false}}
   end
-
-  def handle_cast({:end_udp, [{:host, _host}]}, state) do
+ 
+  def handle_event({:end_udp, [{:host, _host}]}, state) do
     :folsom_metrics.notify({:udp_request_meter, 1})
     :folsom_metrics.notify({:udp_request_counter, {:inc, 1}})
-    {:noreply, state}
+    {:ok, state}
   end
-
-  def handle_cast({:end_tcp, [{:host, _host}]}, state) do
+ 
+  def handle_event({:end_tcp, [{:host, _host}]}, state) do
     :folsom_metrics.notify({:tcp_request_meter, 1})
     :folsom_metrics.notify({:tcp_request_counter, {:inc, 1}})
-    {:noreply, state}
+    {:ok, state}
   end
-
-  def handle_cast({:udp_error, reason}, state) do
+ 
+  def handle_event({:udp_error, reason}, state) do
     :folsom_metrics.notify({:udp_error_meter, 1})
     :folsom_metrics.notify({:udp_error_history, reason})
-    {:noreply, state}
+    {:ok, state}
   end
-
-  def handle_cast({:tcp_error, reason}, state) do
+ 
+  def handle_event({:tcp_error, reason}, state) do
     :folsom_metrics.notify({:tcp_error_meter, 1})
     :folsom_metrics.notify({:tcp_error_history, reason})
-    {:noreply, state}
+    {:ok, state}
   end
-
-  def handle_cast({:refused_response, questions}, state) do
+ 
+  def handle_event({:refused_response, questions}, state) do
     :folsom_metrics.notify({:refused_response_meter, 1})
     :folsom_metrics.notify({:refused_response_counter, {:inc, 1}})
     Logger.debug("Refused response: #{inspect questions}")
-    {:noreply, state}
+    {:ok, state}
   end
-
-  def handle_cast({:empty_response, message}, state) do
+ 
+  def handle_event({:empty_response, message}, state) do
     :folsom_metrics.notify({:empty_response_meter, 1})
     :folsom_metrics.notify({:empty_response_counter, {:inc, 1}})
     Logger.info("Empty response: #{inspect message}")
-    {:noreply, state}
+    {:ok, state}
   end
-
-  def handle_cast({:dnssec_request, _host, _qname}, state) do
+ 
+  def handle_event({:dnssec_request, _host, _qname}, state) do
     :folsom_metrics.notify(:dnssec_request_meter, 1)
     :folsom_metrics.notify(:dnssec_request_counter, {:inc, 1})
-    {:noreply, state}
+    {:ok, state}
   end
-
-  def handle_cast(_cast, state) do
-    {:noreply, state}
+ 
+  def handle_event(_event, state) do
+    {:ok, state}
   end
 end

--- a/lib/exdns/handler.ex
+++ b/lib/exdns/handler.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Handler do
+defmodule ExDNS.Handler do
   @moduledoc """
   Functions for handling DNS messages.
 
@@ -7,13 +7,13 @@ defmodule Exdns.Handler do
 
   require Logger
   require Record
-  require Exdns.Records
+  require ExDNS.Records
 
   def handle({:trailing_garbage, message, _}, context) do
     handle(message, context)
   end
   def handle(message, context = {_, host}) when Record.is_record(message, :dns_message) do
-    handle(message, host, Exdns.QueryThrottle.throttle(message, context))
+    handle(message, host, ExDNS.QueryThrottle.throttle(message, context))
   end
   def handle(bad_message, {_, _host}) do
     bad_message
@@ -24,13 +24,13 @@ defmodule Exdns.Handler do
   defp handle(message, host, {:throttled, host, _req_count}) do
     :folsom_metrics.notify({:request_throttled_counter, {:inc, 1}})
     :folsom_metrics.notify({:request_throttled_meter, 1})
-    Exdns.Records.dns_message(message, tc: true, aa: true, rc: :dns_terms_const.dns_rcode_noerror)
+    ExDNS.Records.dns_message(message, tc: true, aa: true, rc: :dns_terms_const.dns_rcode_noerror)
   end
   defp handle(message, host, _) do
-    Logger.debug("Questions: #{inspect Exdns.Records.dns_message(message, :questions)}")
-    Exdns.Events.notify({:start_handle, [{:host, host}, {:message, message}]})
+    Logger.debug("Questions: #{inspect ExDNS.Records.dns_message(message, :questions)}")
+    ExDNS.Events.notify({:start_handle, [{:host, host}, {:message, message}]})
     response = :folsom_metrics.histogram_timed_update(:request_handled_histogram, __MODULE__, :do_handle, [message, host])
-    Exdns.Events.notify({:end_handle, [{:host, host}, {:message, message}, {:response, response}]})
+    ExDNS.Events.notify({:end_handle, [{:host, host}, {:message, message}, {:response, response}]})
     response
   end
 
@@ -41,46 +41,46 @@ defmodule Exdns.Handler do
   end
 
   defp handle_message(message, host) do
-    case Exdns.PacketCache.get(Exdns.Records.dns_message(message, :questions), host) do
+    case ExDNS.PacketCache.get(ExDNS.Records.dns_message(message, :questions), host) do
       {:ok, cached_response} ->
-        Exdns.Events.notify({:packet_cache_hit, [{:host, host}, {:message, message}]})
-        Exdns.Records.dns_message(cached_response, id: Exdns.Records.dns_message(message, :id))
+        ExDNS.Events.notify({:packet_cache_hit, [{:host, host}, {:message, message}]})
+        ExDNS.Records.dns_message(cached_response, id: ExDNS.Records.dns_message(message, :id))
       {:error, reason} ->
-        Exdns.Events.notify({:packet_cache_miss, [{:reason, reason}, {:host, host}, {:message, message}]})
+        ExDNS.Events.notify({:packet_cache_miss, [{:reason, reason}, {:host, host}, {:message, message}]})
         handle_packet_cache_miss(message, get_authority(message), host) # SOA lookup
     end
   end
 
   defp handle_packet_cache_miss(message, [], _host) do
-    if Exdns.Config.use_root_hints? do
-      {authority, additional} = Exdns.Records.root_hints()
-      Exdns.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_refused, authority: authority, additional: additional)
+    if ExDNS.Config.use_root_hints? do
+      {authority, additional} = ExDNS.Records.root_hints()
+      ExDNS.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_refused, authority: authority, additional: additional)
     else
-      Exdns.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_refused)
+      ExDNS.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_refused)
     end
   end
   defp handle_packet_cache_miss(message, authority, host) do
-    safe_handle_packet_cache_miss(Exdns.Records.dns_message(message, ra: false), authority, host)
+    safe_handle_packet_cache_miss(ExDNS.Records.dns_message(message, ra: false), authority, host)
   end
 
   defp safe_handle_packet_cache_miss(message, authority, host) do
-    if Exdns.Config.catch_exceptions? do
+    if ExDNS.Config.catch_exceptions? do
       try do
-        message = Exdns.Resolver.resolve(message, authority, host)
-        maybe_cache_packet(message, Exdns.Records.dns_message(message, :aa))
+        message = ExDNS.Resolver.resolve(message, authority, host)
+        maybe_cache_packet(message, ExDNS.Records.dns_message(message, :aa))
       rescue
         _exception ->
           # Logger.error("Error answering request: #{inspect exception}")
-          Exdns.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_servfail)
+          ExDNS.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_servfail)
       end
     else
-      message = Exdns.Resolver.resolve(message, authority, host)
-      maybe_cache_packet(message, Exdns.Records.dns_message(message, :aa))
+      message = ExDNS.Resolver.resolve(message, authority, host)
+      maybe_cache_packet(message, ExDNS.Records.dns_message(message, :aa))
     end
   end
 
   defp maybe_cache_packet(message, true) do
-    Exdns.PacketCache.put(Exdns.Records.dns_message(message, :questions), message)
+    ExDNS.PacketCache.put(ExDNS.Records.dns_message(message, :questions), message)
     message
   end
 
@@ -89,31 +89,31 @@ defmodule Exdns.Handler do
   end
 
   defp get_authority(message_or_name) do
-    case Exdns.Zone.Cache.get_authority(message_or_name) do
+    case ExDNS.Zone.Cache.get_authority(message_or_name) do
       {:ok, authority} -> [authority]
       {:error, _} -> []
     end
   end
 
   defp complete_response(message) do
-    notify_empty_response(Exdns.Records.dns_message(message,
-      anc: length(Exdns.Records.dns_message(message, :answers)),
-      auc: length(Exdns.Records.dns_message(message, :authority)),
-      adc: length(Exdns.Records.dns_message(message, :additional)),
+    notify_empty_response(ExDNS.Records.dns_message(message,
+      anc: length(ExDNS.Records.dns_message(message, :answers)),
+      auc: length(ExDNS.Records.dns_message(message, :authority)),
+      adc: length(ExDNS.Records.dns_message(message, :additional)),
       qr: true
     ))
   end
 
   defp notify_empty_response(message) do
-    rr_count = Exdns.Records.dns_message(message, :anc) + Exdns.Records.dns_message(message, :auc) + Exdns.Records.dns_message(message, :adc)
+    rr_count = ExDNS.Records.dns_message(message, :anc) + ExDNS.Records.dns_message(message, :auc) + ExDNS.Records.dns_message(message, :adc)
 
     dns_rcode_refused = :dns_terms_const.dns_rcode_refused()
-    case {Exdns.Records.dns_message(message, :rc), rr_count} do
+    case {ExDNS.Records.dns_message(message, :rc), rr_count} do
       {^dns_rcode_refused, _} ->
-        Exdns.Events.notify({:refused_response, Exdns.Records.dns_message(message, :questions)})
+        ExDNS.Events.notify({:refused_response, ExDNS.Records.dns_message(message, :questions)})
         message
       {_, 0} ->
-        Exdns.Events.notify({:empty_response, message})
+        ExDNS.Events.notify({:empty_response, message})
         message
       _ ->
         message

--- a/lib/exdns/handler/registry.ex
+++ b/lib/exdns/handler/registry.ex
@@ -1,24 +1,24 @@
-defmodule Exdns.Handler.Registry do
+defmodule ExDNS.Handler.Registry do
   @moduledoc """
   Registry for custom handlers. 
   """
 
   use GenServer
 
-  def start_link do
-    GenServer.start_link(__MODULE__, [], name: Exdns.Handler.Registry)
+  def start_link([]) do
+    GenServer.start_link(__MODULE__, [], name: ExDNS.Handler.Registry)
   end
 
   def register_handler(record_types, module) do
-    GenServer.call(Exdns.Handler.Registry, {:register_handler, record_types, module})
+    GenServer.call(ExDNS.Handler.Registry, {:register_handler, record_types, module})
   end
 
   def get_handlers do
-    GenServer.call(Exdns.Handler.Registry, {:get_handlers})
+    GenServer.call(ExDNS.Handler.Registry, {:get_handlers})
   end
 
   def clear do
-    GenServer.call(Exdns.Handler.Registry, :clear)
+    GenServer.call(ExDNS.Handler.Registry, :clear)
   end
 
   ## Server callbacks

--- a/lib/exdns/query_throttle.ex
+++ b/lib/exdns/query_throttle.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.QueryThrottle do
+defmodule ExDNS.QueryThrottle do
   @moduledoc """
   Implements query throttling.
 
@@ -6,15 +6,15 @@ defmodule Exdns.QueryThrottle do
   """
 
   use GenServer
-  require Exdns.Records
+  require ExDNS.Records
 
   @limit 1
   @expiration 60
   @enabled true
   @sweep_interval 1000 * 60 * 5
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: Exdns.QueryThrottle)
+  def start_link([]) do
+    GenServer.start_link(__MODULE__, [], name: ExDNS.QueryThrottle)
   end
 
   def throttle(_message, {:tcp, _host}) do
@@ -23,8 +23,8 @@ defmodule Exdns.QueryThrottle do
 
   def throttle(message, {_, host}) do
     if @enabled do
-      questions = Exdns.Records.dns_message(message, :questions)
-      matches = Enum.filter(questions, fn(q) -> Exdns.Records.dns_query(q, :type) == :dns_terms_const.dns_type_any end)
+      questions = ExDNS.Records.dns_message(message, :questions)
+      matches = Enum.filter(questions, fn(q) -> ExDNS.Records.dns_query(q, :type) == :dns_terms_const.dns_type_any end)
       case matches do
         [] -> :ok
         _ -> record_request(maybe_throttle(host))
@@ -35,31 +35,31 @@ defmodule Exdns.QueryThrottle do
   end
 
   def clear() do
-    GenServer.call(Exdns.QueryThrottle, :clear)
+    GenServer.call(ExDNS.QueryThrottle, :clear)
   end
 
   def sweep() do
-    GenServer.call(Exdns.QueryThrottle, :sweep)
+    GenServer.call(ExDNS.QueryThrottle, :sweep)
   end
 
   def stop() do
-    GenServer.call(Exdns.QueryThrottle, :stop)
+    GenServer.call(ExDNS.QueryThrottle, :stop)
   end
 
   # GenServer callbacks
 
   def init([]) do
-    Exdns.Storage.create(:host_throttle)
-    {:ok, tref} = :timer.apply_interval(@sweep_interval, Exdns.QueryThrottle, :sweep, [])
+    ExDNS.Storage.create(:host_throttle)
+    {:ok, tref} = :timer.apply_interval(@sweep_interval, ExDNS.QueryThrottle, :sweep, [])
     {:ok, %{tref: tref}}
   end
   def handle_call(:clear, _from, state) do
-    Exdns.Storage.empty_table(:host_throttle)
+    ExDNS.Storage.empty_table(:host_throttle)
     {:reply, :ok, state}
   end
   def handle_call(:sweep, _from, state) do
-    Exdns.Storage.select(:host_throttle, [{{:"$1", {:"_", :"$2"}}, [{:<, :"$2", Exdns.timestamp() - @expiration}], [:"$1"]}], :infinite) |>
-      Enum.each(fn(k) -> Exdns.Storage.delete(:host_throttle, k) end)
+    ExDNS.Storage.select(:host_throttle, [{{:"$1", {:"_", :"$2"}}, [{:<, :"$2", ExDNS.timestamp() - @expiration}], [:"$1"]}], :infinite) |>
+      Enum.each(fn(k) -> ExDNS.Storage.delete(:host_throttle, k) end)
     {:reply, :ok, state}
   end
   def handle_call(:stop, _from, state) do
@@ -69,7 +69,7 @@ defmodule Exdns.QueryThrottle do
   # Private functions
 
   defp maybe_throttle(host) do
-    case Exdns.Storage.select(:host_throttle, host) do
+    case ExDNS.Storage.select(:host_throttle, host) do
       [{^host, {req_count, last_request_at}}] ->
         case is_throttled(host, req_count, last_request_at) do
           {true, new_req_count} -> {:throttled, host, new_req_count}
@@ -81,7 +81,7 @@ defmodule Exdns.QueryThrottle do
   end
 
   defp record_request({throttle_response, host, req_count}) do
-    Exdns.Storage.insert(:host_throttle, {host, {req_count, Exdns.timestamp()}})
+    ExDNS.Storage.insert(:host_throttle, {host, {req_count, ExDNS.timestamp()}})
     {throttle_response, host, req_count}
   end
 
@@ -90,9 +90,9 @@ defmodule Exdns.QueryThrottle do
   end
   defp is_throttled(host, req_count, last_request_at) do
     exceeds_limit = req_count >= @limit
-    expired = Exdns.timestamp() - last_request_at > @expiration
+    expired = ExDNS.timestamp() - last_request_at > @expiration
     if expired do
-      Exdns.Storage.delete(:host_throttle, host)
+      ExDNS.Storage.delete(:host_throttle, host)
       {false, 1}
     else
       {exceeds_limit, req_count + 1}

--- a/lib/exdns/records.ex
+++ b/lib/exdns/records.ex
@@ -1,5 +1,5 @@
 # Imports all of the records from dns_erlang/include/dns_records.hrl
-defmodule Exdns.Records do
+defmodule ExDNS.Records do
   @moduledoc """
   Functions for DNS record construction, filtering and other record utilities.
   """

--- a/lib/exdns/resolver.ex
+++ b/lib/exdns/resolver.ex
@@ -1,14 +1,14 @@
-defmodule Exdns.Resolver do
+defmodule ExDNS.Resolver do
   @moduledoc """
   Provides the core logic for deciding what records to return for DNS queries.
   """
 
   require Record
   require Logger
-  require Exdns.Records
+  require ExDNS.Records
 
   def resolve(message, authority, host) do
-    case Exdns.Records.dns_message(message, :questions) do
+    case ExDNS.Records.dns_message(message, :questions) do
       [] -> message
       [question] -> resolve(message, authority, host, question)
       [question|_] -> resolve(message, authority, host, question)
@@ -20,13 +20,13 @@ defmodule Exdns.Resolver do
   # Step 1 - Set the RA bit to false as we do not handle recursive queries.
   def resolve(message, authority, host, question) do
     check_dnssec(message, host, question)
-    resolve(Exdns.Records.dns_message(message, ra: false, ad: false), authority, Exdns.Records.dns_query(question, :name), Exdns.Records.dns_query(question, :type), host)
+    resolve(ExDNS.Records.dns_message(message, ra: false, ad: false), authority, ExDNS.Records.dns_query(question, :name), ExDNS.Records.dns_query(question, :type), host)
   end
 
   # Step 2: Search the available zones for the zone which is the nearest ancestor to qname
   # With the qname and qtype in hand, find the nearest zone.
   def resolve(message, authority, qname, qtype, host) do
-    zone = Exdns.Zone.Cache.find_zone(qname, authority)
+    zone = ExDNS.Zone.Cache.find_zone(qname, authority)
     message = resolve(message, qname, qtype, zone, host, _cname_chain = [])
     rewrite_soa_ttl(message) |> additional_processing(host, zone)
   end
@@ -35,15 +35,15 @@ defmodule Exdns.Resolver do
   # If no SOA was found, return a no error result.
   # If an SOA is found then start the resolution to match the appropriate records.
   def resolve(message, _, _, {:error, :not_authoritative}, _, _) do
-    if Exdns.Config.use_root_hints? do
-      {authority, additional} = Exdns.Records.root_hints()
-      Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, authority: authority, additional: additional)
+    if ExDNS.Config.use_root_hints? do
+      {authority, additional} = ExDNS.Records.root_hints()
+      ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, authority: authority, additional: additional)
     else
-      Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror)
+      ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror)
     end
   end
   def resolve(message, qname, qtype, zone, host, cname_chain) do
-    case Enum.dedup(Exdns.Zone.Cache.get_records_by_name(qname)) do
+    case Enum.dedup(ExDNS.Zone.Cache.get_records_by_name(qname)) do
       [] ->
         Logger.debug("No exact match by name, using best match resolution")
         best_match_resolution(message, qname, qtype, host, cname_chain, best_match(qname, zone), zone)
@@ -60,7 +60,7 @@ defmodule Exdns.Resolver do
 
   # Determine if there is a CNAME anywhere in the records with the given qname.
   def exact_match_resolution(message, qname, qtype, host, cname_chain, matched_records, zone) do
-    case Enum.filter(matched_records, Exdns.Records.match_type(:dns_terms_const.dns_type_cname)) do
+    case Enum.filter(matched_records, ExDNS.Records.match_type(:dns_terms_const.dns_type_cname)) do
       [] ->
         Logger.debug("Found no CNAME records with the given qname")
         resolve_exact_match(message, qname, qtype, host, cname_chain, matched_records, zone)
@@ -73,16 +73,16 @@ defmodule Exdns.Resolver do
   # There were no CNAMEs found in the exact name matches, so now grab the authority records
   # and find any type matches on qtype and continue.
   def resolve_exact_match(message, qname, qtype, host, cname_chain, matched_records, zone) do
-    authority_records = Enum.filter(matched_records, Exdns.Records.match_type(:dns_terms_const.dns_type_soa))
+    authority_records = Enum.filter(matched_records, ExDNS.Records.match_type(:dns_terms_const.dns_type_soa))
     any_type = :dns_terms_const.dns_type_any
     type_matches = case qtype do
-      ^any_type -> filter_records(matched_records, Exdns.Handler.Registry.get_handlers())
-      _ -> Enum.filter(matched_records, Exdns.Records.match_type(qtype))
+      ^any_type -> filter_records(matched_records, ExDNS.Handler.Registry.get_handlers())
+      _ -> Enum.filter(matched_records, ExDNS.Records.match_type(qtype))
     end
     case type_matches do
       [] ->
         Logger.debug("Found no type matches")
-        records = List.flatten(Enum.map(Exdns.Handler.Registry.get_handlers(), custom_lookup(qname, qtype, matched_records)))
+        records = List.flatten(Enum.map(ExDNS.Handler.Registry.get_handlers(), custom_lookup(qname, qtype, matched_records)))
         resolve_exact_match(message, qname, qtype, host, cname_chain, matched_records, zone, records, authority_records)
       _ ->
         Logger.debug("Found type matches")
@@ -93,7 +93,7 @@ defmodule Exdns.Resolver do
   def resolve_exact_match(message, qname, qtype, host, cname_chain, matched_records, zone, exact_type_matches, authority_records) do
     case exact_type_matches do
       [] ->
-        referral_records = Enum.filter(matched_records, Exdns.Records.match_type(:dns_terms_const.dns_type_ns))
+        referral_records = Enum.filter(matched_records, ExDNS.Records.match_type(:dns_terms_const.dns_type_ns))
         resolve_no_exact_type_match(message, qtype, host, cname_chain, [], zone, matched_records, referral_records, authority_records)
       _ ->
         resolve_exact_type_match(message, qname, qtype, host, cname_chain, exact_type_matches, zone, authority_records)
@@ -108,28 +108,28 @@ defmodule Exdns.Resolver do
         case authority_records do
           [] ->
             # Exact type match for NS query, but there is no SOA for the zone
-            name = Exdns.Records.dns_rr(List.last(matched_records), :name)
+            name = ExDNS.Records.dns_rr(List.last(matched_records), :name)
             # It isn't clear what the qtype should be on a delegated start, so I assume an A record
-            restart_delegated_query(message, name, :dns_terms_const.dns_type_a, host, cname_chain, zone, Exdns.Zone.Cache.in_zone?(name))
+            restart_delegated_query(message, name, :dns_terms_const.dns_type_a, host, cname_chain, zone, ExDNS.Zone.Cache.in_zone?(name))
           _ ->
             # Exact type match for NS query and there is an SOA records.
-            answers = Exdns.Records.dns_message(message, :answers) ++ matched_records
-            Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: answers)
+            answers = ExDNS.Records.dns_message(message, :answers) ++ matched_records
+            ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: answers)
         end
       _ ->
         # Exact type match for something other than an NS record and the SOA is present
         Logger.debug("Exact type match for something other than NS and SOA is present: #{inspect matched_records}")
         answer = List.last(matched_records)
-        case ns_records = Exdns.Zone.Cache.get_delegations(Exdns.Records.dns_rr(answer, :name)) do
+        case ns_records = ExDNS.Zone.Cache.get_delegations(ExDNS.Records.dns_rr(answer, :name)) do
           [] ->
             resolve_exact_type_match(message, qname, qtype, host, cname_chain, matched_records, zone, authority_records, _ns_records = [])
           _ ->
             ns_record = List.last(ns_records)
-            case Exdns.Zone.Cache.get_authority(qname) do
+            case ExDNS.Zone.Cache.get_authority(qname) do
               {:ok, soa_record} ->
-                if Exdns.Records.dns_rr(soa_record, :name) == Exdns.Records.dns_rr(ns_record, :name) do
+                if ExDNS.Records.dns_rr(soa_record, :name) == ExDNS.Records.dns_rr(ns_record, :name) do
                   answers = merge_with_answers(message, matched_records)
-                  Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: answers)
+                  ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: answers)
                 else
                   resolve_exact_type_match(message, qname, qtype, host, cname_chain, matched_records, zone, authority_records, ns_records)
                 end
@@ -142,7 +142,7 @@ defmodule Exdns.Resolver do
   # We are authoritative and there are no NS records here
   def resolve_exact_type_match(message, _qname, _qtype, _host, _cname_chain, matched_records, _zone, _authority_records, []) do
     Logger.debug("Resolved exact type match and there are no NS records: #{inspect matched_records}")
-    Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: merge_with_answers(message, matched_records))
+    ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: merge_with_answers(message, matched_records))
   end
   # We are authoritative and there are NS records here
   def resolve_exact_type_match(message, _qname, qtype, host, cname_chain, matched_records, zone, _authority_records, ns_records) do
@@ -150,17 +150,17 @@ defmodule Exdns.Resolver do
     # NOTE: there is a potential bug here because it assumes the last record is the one to examine
     answer = List.last(matched_records)
     ns_record = List.last(ns_records)
-    name = Exdns.Records.dns_rr(ns_record, :name)
-    if name == Exdns.Records.dns_rr(answer, :name) do
+    name = ExDNS.Records.dns_rr(ns_record, :name)
+    if name == ExDNS.Records.dns_rr(answer, :name) do
       Logger.debug("NS record name matches the answer name")
-      Exdns.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_noerror, authority: merge_with_authority(message, ns_records))
+      ExDNS.Records.dns_message(message, aa: false, rc: :dns_terms_const.dns_rcode_noerror, authority: merge_with_authority(message, ns_records))
     else
       # TODO: only restart delegation if the NS record is on a parent node
       # if it is a sibling then we should not restart
-      if parent?(name, Exdns.Records.dns_rr(answer, :name)) do
-        restart_delegated_query(message, name, qtype, host, cname_chain, zone, Exdns.Zone.Cache.in_zone?(name))
+      if parent?(name, ExDNS.Records.dns_rr(answer, :name)) do
+        restart_delegated_query(message, name, qtype, host, cname_chain, zone, ExDNS.Zone.Cache.in_zone?(name))
       else
-        Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: merge_with_answers(message, matched_records))
+        ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, answers: merge_with_answers(message, matched_records))
       end
     end
   end
@@ -177,11 +177,11 @@ defmodule Exdns.Resolver do
   def resolve_no_exact_type_match(message, qtype, _host, _cname_chain, exact_type_matches, zone, matched_records, referral_records, authority_records) do
     any_type = :dns_terms_const.dns_type_any
     case qtype do
-      ^any_type -> Exdns.Records.dns_message(message, aa: true, authority: authority_records)
+      ^any_type -> ExDNS.Records.dns_message(message, aa: true, authority: authority_records)
       _ ->
         case {referral_records, exact_type_matches} do
-          {[], []} -> Exdns.Records.dns_message(message, aa: true, authority: [zone.authority])
-          {[], _} -> Exdns.Records.dns_message(message, aa: true, answers: merge_with_answers(message, exact_type_matches))
+          {[], []} -> ExDNS.Records.dns_message(message, aa: true, authority: [zone.authority])
+          {[], _} -> ExDNS.Records.dns_message(message, aa: true, answers: merge_with_answers(message, exact_type_matches))
           {_, _} -> resolve_exact_match_referral(message, qtype, matched_records, referral_records, authority_records)
         end
     end
@@ -191,7 +191,7 @@ defmodule Exdns.Resolver do
   # Given an exact name match where the qtype is not found in the record set, and we are not authoritative,
   # add the NS records to the authority section of the message.
   def resolve_exact_match_referral(message, _qtype, _matched_records, referral_records, []) do
-    Exdns.Records.dns_message(message, authority: merge_with_authority(message, referral_records))
+    ExDNS.Records.dns_message(message, authority: merge_with_authority(message, referral_records))
   end
   def resolve_exact_match_referral(message, qtype, matched_records, referral_records, authority_records) do
     any_type = :dns_terms_const.dns_type_any
@@ -199,10 +199,10 @@ defmodule Exdns.Resolver do
     soa_type = :dns_terms_const.dns_type_soa
 
     case qtype do
-      ^any_type -> Exdns.Records.dns_message(message, aa: true, answers: matched_records)
-      ^ns_type -> Exdns.Records.dns_message(message, aa: true, answers: referral_records)
-      ^soa_type -> Exdns.Records.dns_message(message, aa: true, answers: authority_records)
-      _ -> Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, authority: authority_records)
+      ^any_type -> ExDNS.Records.dns_message(message, aa: true, answers: matched_records)
+      ^ns_type -> ExDNS.Records.dns_message(message, aa: true, answers: referral_records)
+      ^soa_type -> ExDNS.Records.dns_message(message, aa: true, answers: authority_records)
+      _ -> ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, authority: authority_records)
     end
   end
 
@@ -212,13 +212,13 @@ defmodule Exdns.Resolver do
     case qtype do
       ^cname_type ->
         Logger.debug("Qtype is CNAME, returning the CNAME records: #{inspect cname_records}")
-        Exdns.Records.dns_message(message, aa: true, answers: merge_with_answers(message, cname_records))
+        ExDNS.Records.dns_message(message, aa: true, answers: merge_with_answers(message, cname_records))
       _ ->
         if Enum.member?(cname_chain, List.last(cname_records)) do
-          Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_servfail) # CNAME loop
+          ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_servfail) # CNAME loop
         else
-          name = Exdns.Records.dns_rr(List.last(cname_records), :data) |> Exdns.Records.dns_rrdata_cname(:dname)
-          restart_query(Exdns.Records.dns_message(message, aa: true, answers: Exdns.Records.dns_message(message, :answers) ++ cname_records), name, qtype, host, cname_chain ++ cname_records, zone, Exdns.Zone.Cache.in_zone?(name))
+          name = ExDNS.Records.dns_rr(List.last(cname_records), :data) |> ExDNS.Records.dns_rrdata_cname(:dname)
+          restart_query(ExDNS.Records.dns_message(message, aa: true, answers: ExDNS.Records.dns_message(message, :answers) ++ cname_records), name, qtype, host, cname_chain ++ cname_records, zone, ExDNS.Zone.Cache.in_zone?(name))
         end
     end
   end
@@ -230,7 +230,7 @@ defmodule Exdns.Resolver do
       resolve(message, name, qtype, zone, host, cname_chain)
     else
       # The CNAME is not in the zone so we need to find the zone using the CNAME content
-      resolve(message, name, qtype, Exdns.Zone.Cache.find_zone(name), host, cname_chain)
+      resolve(message, name, qtype, ExDNS.Zone.Cache.find_zone(name), host, cname_chain)
     end
   end
 
@@ -239,7 +239,7 @@ defmodule Exdns.Resolver do
     if in_zone do
       resolve(message, name, qtype, zone, host, cname_chain)
     else
-      resolve(message, name, qtype, Exdns.Zone.Cache.find_zone(name, zone.authority), host, cname_chain)
+      resolve(message, name, qtype, ExDNS.Zone.Cache.find_zone(name, zone.authority), host, cname_chain)
     end
   end
 
@@ -252,7 +252,7 @@ defmodule Exdns.Resolver do
   # If there are no NS records in the matches then this is not a referral.
   # If there are NS records in the best matches this is a referral.
   def best_match_resolution(message, qname, qtype, host, cname_chain, best_match_records, zone) do
-    referral_records = Enum.filter(best_match_records, Exdns.Records.match_type(:dns_terms_const.dns_type_ns)) # NS lookup
+    referral_records = Enum.filter(best_match_records, ExDNS.Records.match_type(:dns_terms_const.dns_type_ns)) # NS lookup
     case referral_records do
       [] -> resolve_best_match(message, qname, qtype, host, cname_chain, best_match_records, zone)
       _ -> resolve_best_match_referral(message, qname, qtype, host, cname_chain, best_match_records, zone, referral_records)
@@ -264,23 +264,23 @@ defmodule Exdns.Resolver do
   # If there is no wildcard then the result is NXDOMAIN.
   def resolve_best_match(message, qname, qtype, host, cname_chain, best_match_records, zone) do
     Logger.debug("No referral present, trying wildcard")
-    if Enum.any?(best_match_records, Exdns.Records.match_wildcard) do
+    if Enum.any?(best_match_records, ExDNS.Records.match_wildcard) do
       cname_records =
-        Enum.map(best_match_records, Exdns.Records.replace_name(qname)) |>
-        Enum.filter(Exdns.Records.match_type(:dns_terms_const.dns_type_cname))
+        Enum.map(best_match_records, ExDNS.Records.replace_name(qname)) |>
+        Enum.filter(ExDNS.Records.match_type(:dns_terms_const.dns_type_cname))
       resolve_best_match_with_wildcard(message, qname, qtype, host, cname_chain, best_match_records, zone, cname_records)
     else
-      [q|_] = Exdns.Records.dns_message(message, :questions)
-      if qname == Exdns.Records.dns_query(q, :name) do
-        Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_nxdomain, authority: [zone.authority])
+      [q|_] = ExDNS.Records.dns_message(message, :questions)
+      if qname == ExDNS.Records.dns_query(q, :name) do
+        ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_nxdomain, authority: [zone.authority])
       else
         # This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
         # something other than CNAME. Note that the response is still NOERROR error.
         #
         # In the dnstest suite, this is tested by cname_to_unauth_any (and others)
-        if Exdns.Config.use_root_hints? do
-          {authority, additional} = Exdns.Records.root_hints()
-          Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, authority: authority, additional: additional)
+        if ExDNS.Config.use_root_hints? do
+          {authority, additional} = ExDNS.Records.root_hints()
+          ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_noerror, authority: authority, additional: additional)
         else
           message
         end
@@ -295,15 +295,15 @@ defmodule Exdns.Resolver do
       [] ->
         Logger.debug("No CNAME records, checking for type matches in #{inspect matched_records}")
         records = type_match_records(matched_records, qtype)
-        type_matches = Enum.map(records, Exdns.Records.replace_name(qname))
+        type_matches = Enum.map(records, ExDNS.Records.replace_name(qname))
         case type_matches do
           [] ->
             # Ask custom handlers for their records
             records =
-              Exdns.Handler.Registry.get_handlers() |>
+              ExDNS.Handler.Registry.get_handlers() |>
               Enum.map(custom_lookup(qname, qtype, matched_records)) |>
               List.flatten |>
-              Enum.map(Exdns.Records.replace_name(qname))
+              Enum.map(ExDNS.Records.replace_name(qname))
             resolve_best_match_with_wildcard(message, qname, qtype, host, cname_chain, matched_records, zone, [], records)
           _ ->
             resolve_best_match_with_wildcard(message, qname, qtype, host, cname_chain, matched_records, zone, [], type_matches)
@@ -313,10 +313,10 @@ defmodule Exdns.Resolver do
     end
   end
   def resolve_best_match_with_wildcard(message, _qname, _qtype, _host, _cname_chain, _best_match_records, zone, [], []) do
-    Exdns.Records.dns_message(message, aa: true, authority: [zone.authority])
+    ExDNS.Records.dns_message(message, aa: true, authority: [zone.authority])
   end
   def resolve_best_match_with_wildcard(message, _qname, _qtype, _host, _cname_chain, _best_match_records, _zone, [], type_matches) do
-    Exdns.Records.dns_message(message, aa: true, answers: merge_with_answers(message, type_matches))
+    ExDNS.Records.dns_message(message, aa: true, answers: merge_with_answers(message, type_matches))
   end
 
 
@@ -324,16 +324,16 @@ defmodule Exdns.Resolver do
     cname_type = :dns_terms_const.dns_type_cname
     case qtype do
       ^cname_type ->
-        Exdns.Records.dns_message(message, aa: true, answers: merge_with_answers(message, cname_records))
+        ExDNS.Records.dns_message(message, aa: true, answers: merge_with_answers(message, cname_records))
       _ ->
         # There should only be one CNAME, Multiple CNAMEs kill unicorns.
         cname_record = List.last(cname_records)
         if Enum.member?(cname_chain, cname_record) do
-          Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_servfail)
+          ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_servfail)
         else
-          name = Exdns.Records.dns_rr(cname_record, :data) |> Exdns.Records.dns_rrdata_cname(:dname)
-          Exdns.Records.dns_message(message, aa: true, answers: merge_with_answers(message, cname_records)) |>
-            restart_query(name, qtype, host, cname_chain ++ cname_records, zone, Exdns.Zone.Cache.in_zone?(name))
+          name = ExDNS.Records.dns_rr(cname_record, :data) |> ExDNS.Records.dns_rrdata_cname(:dname)
+          ExDNS.Records.dns_message(message, aa: true, answers: merge_with_answers(message, cname_records)) |>
+            restart_query(name, qtype, host, cname_chain ++ cname_records, zone, ExDNS.Zone.Cache.in_zone?(name))
         end
     end
   end
@@ -344,17 +344,17 @@ defmodule Exdns.Resolver do
   # If there are no SOA records present then we indicate we are not authoritivate for the name.
   # If there is an SOA record then we authoritative for the name
   def resolve_best_match_referral(message, _qname, qtype, _host, cname_chain, best_match_records, _zone, referral_records) do
-    authority = Enum.filter(best_match_records, Exdns.Records.match_type(:dns_terms_const.dns_type_soa))
+    authority = Enum.filter(best_match_records, ExDNS.Records.match_type(:dns_terms_const.dns_type_soa))
     any_type = :dns_terms_const.dns_type_any
     case {qtype, cname_chain, authority} do
       {_, _, []} ->
-        Exdns.Records.dns_message(message, aa: false, authority: merge_with_authority(message, referral_records))
+        ExDNS.Records.dns_message(message, aa: false, authority: merge_with_authority(message, referral_records))
       {_, [], _} ->
-        Exdns.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_nxdomain, authority: authority)
+        ExDNS.Records.dns_message(message, aa: true, rc: :dns_terms_const.dns_rcode_nxdomain, authority: authority)
       {^any_type, _, _} ->
         message
       {_, _, _} ->
-        Exdns.Records.dns_message(message, authority: authority)
+        ExDNS.Records.dns_message(message, authority: authority)
     end
   end
 
@@ -365,14 +365,14 @@ defmodule Exdns.Resolver do
   def best_match(_, [], _), do: []
   # Wildcard
   def best_match(qname, [_|rest], zone) do
-    best_match(qname, rest, zone, Exdns.Zone.Cache.get_records_by_name(:dns.labels_to_dname(["*"] ++ rest)))
+    best_match(qname, rest, zone, ExDNS.Zone.Cache.get_records_by_name(:dns.labels_to_dname(["*"] ++ rest)))
   end
 
   # No labels, no wildcard name
   def best_match(_, [], _, []), do: []
   # Labels, no wildcard name
   def best_match(qname, labels, zone, []) do
-   case Exdns.Zone.Cache.get_records_by_name(:dns.labels_to_dname(labels)) do
+   case ExDNS.Zone.Cache.get_records_by_name(:dns.labels_to_dname(labels)) do
       [] -> best_match(qname, labels, zone)
       matches -> matches
     end
@@ -395,8 +395,8 @@ defmodule Exdns.Resolver do
   def type_match_records(records, qtype) do
     any_type = :dns_terms_const.dns_type_any
     case qtype do
-      ^any_type -> filter_records(records, Exdns.Handler.Registry.get_handlers())
-      _ -> Enum.filter(records, Exdns.Records.match_type(qtype))
+      ^any_type -> filter_records(records, ExDNS.Handler.Registry.get_handlers())
+      _ -> Enum.filter(records, ExDNS.Records.match_type(qtype))
     end
   end
 
@@ -405,26 +405,26 @@ defmodule Exdns.Resolver do
   def filter_records(records, [{handler, _}|rest]), do: filter_records(handler.filter(records), rest)
 
 
-  def rewrite_soa_ttl(message), do: rewrite_soa_ttl(message, Exdns.Records.dns_message(message, :authority), [])
-  def rewrite_soa_ttl(message, [], new_authority), do: Exdns.Records.dns_message(message, authority: new_authority)
+  def rewrite_soa_ttl(message), do: rewrite_soa_ttl(message, ExDNS.Records.dns_message(message, :authority), [])
+  def rewrite_soa_ttl(message, [], new_authority), do: ExDNS.Records.dns_message(message, authority: new_authority)
   def rewrite_soa_ttl(message, [r|rest], new_authority) do
-    rewrite_soa_ttl(message, rest, new_authority ++ [Exdns.Records.minimum_soa_ttl(r, Exdns.Records.dns_rr(r, :data))])
+    rewrite_soa_ttl(message, rest, new_authority ++ [ExDNS.Records.minimum_soa_ttl(r, ExDNS.Records.dns_rr(r, :data))])
   end
 
 
   def additional_processing(message, _host, {:error, _}), do: message
   def additional_processing(message, _host, _zone) do
-    record_names = merge_with_answers(message, Exdns.Records.dns_message(message, :authority)) |> requires_additional_processing([]) |> List.flatten
+    record_names = merge_with_answers(message, ExDNS.Records.dns_message(message, :authority)) |> requires_additional_processing([]) |> List.flatten
     case record_names do
       [] -> message
       _ ->
         records =
-          Enum.map(record_names, fn(name) -> Exdns.Zone.Cache.get_records_by_name(name) end) |>
+          Enum.map(record_names, fn(name) -> ExDNS.Zone.Cache.get_records_by_name(name) end) |>
           List.flatten |>
-          Enum.filter(Exdns.Records.match_types([:dns_terms_const.dns_type_a, :dns_terms_const.dns_type_aaaa]))
+          Enum.filter(ExDNS.Records.match_types([:dns_terms_const.dns_type_a, :dns_terms_const.dns_type_aaaa]))
         case records do
           [] -> message
-          _ -> Exdns.Records.dns_message(message, additional: merge_with_additional(message, records))
+          _ -> ExDNS.Records.dns_message(message, additional: merge_with_additional(message, records))
         end
     end
   end
@@ -432,9 +432,9 @@ defmodule Exdns.Resolver do
 
   def requires_additional_processing([], requires_additional), do: requires_additional
   def requires_additional_processing([answer|rest], requires_additional) do
-    names = case Exdns.Records.dns_rr(answer, :data) do
-      data when Record.is_record(data, :dns_rrdata_ns) -> [Exdns.Records.dns_rrdata_ns(data, :dname)]
-      data when Record.is_record(data, :dns_rrdata_mx) -> [Exdns.Records.dns_rrdata_mx(data, :exchange)]
+    names = case ExDNS.Records.dns_rr(answer, :data) do
+      data when Record.is_record(data, :dns_rrdata_ns) -> [ExDNS.Records.dns_rrdata_ns(data, :dname)]
+      data when Record.is_record(data, :dns_rrdata_mx) -> [ExDNS.Records.dns_rrdata_mx(data, :exchange)]
       _ -> []
     end
     requires_additional_processing(rest, requires_additional ++ names)
@@ -442,8 +442,8 @@ defmodule Exdns.Resolver do
 
 
   def check_dnssec(message, host, question) do
-    if Exdns.Edns.get_opts(message)[:dnssec] do
-      Exdns.Events.notify({:dnssec_request, host, Exdns.Records.dns_query(question, :name)})
+    if ExDNS.Edns.get_opts(message)[:dnssec] do
+      ExDNS.Events.notify({:dnssec_request, host, ExDNS.Records.dns_query(question, :name)})
     end
     :ok
   end
@@ -452,15 +452,15 @@ defmodule Exdns.Resolver do
   # Merges the given `records` with the answers in the given `message` and returns
   # a collection of records.
   defp merge_with_answers(message, records) do
-    Exdns.Records.dns_message(message, :answers) ++ records
+    ExDNS.Records.dns_message(message, :answers) ++ records
   end
 
   defp merge_with_additional(message, records) do
-    Exdns.Records.dns_message(message, :additional) ++ records
+    ExDNS.Records.dns_message(message, :additional) ++ records
   end
 
   defp merge_with_authority(message, records) do
-    Exdns.Records.dns_message(message, :authority) ++ records
+    ExDNS.Records.dns_message(message, :authority) ++ records
   end
 
 end

--- a/lib/exdns/server/supervisor.ex
+++ b/lib/exdns/server/supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Server.Supervisor do
+defmodule ExDNS.Server.Supervisor do
   @moduledoc """
   Supervisor for server processes, including UDP and TCP server processes.
   """
@@ -6,24 +6,24 @@ defmodule Exdns.Server.Supervisor do
   use Supervisor
   require Logger
 
-  def start_link do
-    Supervisor.start_link(__MODULE__, [], name: Exdns.Server.Supervisor)
+  def start_link([]) do
+    Supervisor.start_link(__MODULE__, [], name: ExDNS.Server.Supervisor)
   end
 
   def stop do
-    Supervisor.stop(Exdns.Server.Supervisor)
-    Exdns.Events.notify(:stop_servers)
+    Supervisor.stop(ExDNS.Server.Supervisor)
+    ExDNS.Events.notify(:stop_servers)
     :ok
   end
 
   def stop_children do
-    Supervisor.which_children(Exdns.Server.Supervisor) |>
-      Enum.map(fn(c) -> Supervisor.terminate_child(Exdns.Server.Supervisor, c) end)
+    Supervisor.which_children(ExDNS.Server.Supervisor) |>
+      Enum.map(fn(c) -> Supervisor.terminate_child(ExDNS.Server.Supervisor, c) end)
     :ok
   end
 
   def init(_) do
-    servers = Exdns.Config.servers
+    servers = ExDNS.Config.servers
     if servers == [] and Mix.env != :test, do: Logger.warn("No servers are specified in your config")
     Enum.map(servers, &define_server/1) |> supervise(strategy: :one_for_one)
   end

--- a/lib/exdns/server/tcp_server.ex
+++ b/lib/exdns/server/tcp_server.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Server.TcpServer do
+defmodule ExDNS.Server.TCPServer do
   @moduledoc """
   Server for receiving TCP packets.
   """
@@ -18,7 +18,7 @@ defmodule Exdns.Server.TcpServer do
   # GenServer callbacks
 
   def init([]) do
-    {:ok, %{workers: Exdns.Worker.make_workers(:queue.new())}}
+    {:ok, %{workers: ExDNS.Worker.make_workers(:queue.new())}}
   end
 
   def handle_call(_message, _from, state) do
@@ -30,7 +30,7 @@ defmodule Exdns.Server.TcpServer do
   end
 
   def handle_info(_msg = {:tcp, socket, bin}, state) do
-    _response = :folsom_metrics.histogram_timed_update(:tcp_handoff_histogram, Exdns.Server.TcpServer, :handle_request, [socket, bin, state])
+    _response = :folsom_metrics.histogram_timed_update(:tcp_handoff_histogram, ExDNS.Server.TCPServer, :handle_request, [socket, bin, state])
     :inet.setopts(socket, [{:active, :once}])
     {:noreply, state}
   end

--- a/lib/exdns/server/udp_server.ex
+++ b/lib/exdns/server/udp_server.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Server.UdpServer do
+defmodule ExDNS.Server.UDPServer do
   @moduledoc """
   Server for receiving UDP packets.
   """
@@ -6,11 +6,7 @@ defmodule Exdns.Server.UdpServer do
   use GenServer
   require Logger
 
-  def start_link(name, inet_family, address, port) do
-    start_link(name, inet_family, address, port, [])
-  end
-
-  def start_link(name, inet_family, address, port, socket_opts) do
+  def start_link(name, inet_family, address, port, socket_opts \\ []) do
     Logger.debug("Starting UDP server for #{inet_family} on address #{inspect address} port #{port}")
     GenServer.start_link(__MODULE__, [inet_family, address, port, socket_opts], name: name)
   end
@@ -27,7 +23,7 @@ defmodule Exdns.Server.UdpServer do
 
   def init([inet_family, address, port, socket_opts]) do
     {:ok, socket} = start(address, port, inet_family, socket_opts)
-    {:ok, %{address: address, port: port, socket: socket, workers: Exdns.Worker.make_workers(:queue.new())}}
+    {:ok, %{address: address, port: port, socket: socket, workers: ExDNS.Worker.make_workers(:queue.new())}}
   end
 
   def handle_call(:stop, _from, state) do
@@ -44,7 +40,7 @@ defmodule Exdns.Server.UdpServer do
   end
 
   def handle_info({:udp, socket, host, port, bin}, state) do
-    response = :folsom_metrics.histogram_timed_update(:udp_handoff_histogram, Exdns.Server.UdpServer, :handle_request, [socket, host, port, bin, state])
+    response = :folsom_metrics.histogram_timed_update(:udp_handoff_histogram, ExDNS.Server.UDPServer, :handle_request, [socket, host, port, bin, state])
     :inet.setopts(Map.get(state, :socket), [{:active, :once}])
     response
   end

--- a/lib/exdns/storage.ex
+++ b/lib/exdns/storage.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Storage do
+defmodule ExDNS.Storage do
   @moduledoc """
   Interface for storage engines.
   """
@@ -52,6 +52,6 @@ defmodule Exdns.Storage do
   # Private functions
 
   defp mod() do
-    Exdns.Config.storage_type()
+    ExDNS.Config.storage_type()
   end
 end

--- a/lib/exdns/storage/ets_storage.ex
+++ b/lib/exdns/storage/ets_storage.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Storage.EtsStorage do
+defmodule ExDNS.Storage.EtsStorage do
   @moduledoc """
   Storage engine backed by ETS
   """

--- a/lib/exdns/supervisor.ex
+++ b/lib/exdns/supervisor.ex
@@ -1,23 +1,23 @@
-defmodule Exdns.Supervisor do
+defmodule ExDNS.Supervisor do
   @moduledoc """
-  Exdns application supervisor
+  ExDNS application supervisor
   """
 
   use Supervisor
 
-  def start_link do
-    Supervisor.start_link(__MODULE__, :ok, name: Exdns.Supervisor)
+  def start_link() do
+    Supervisor.start_link(__MODULE__, :ok, name: ExDNS.Supervisor)
   end
 
   def init(_args) do
     children = [
-      worker(Exdns.Events, []),
-      worker(Exdns.Zone.Cache, []),
-      worker(Exdns.Zone.Registry, []),
-      # worker(Exdns.ZoneEncoder, []),
-      worker(Exdns.PacketCache, []),
-      worker(Exdns.QueryThrottle, []),
-      worker(Exdns.Handler.Registry, [])
+      worker(ExDNS.Events, []),
+      worker(ExDNS.Zone.Cache, []),
+      worker(ExDNS.Zone.Registry, []),
+      # worker(ExDNS.ZoneEncoder, []),
+      worker(ExDNS.PacketCache, []),
+      worker(ExDNS.QueryThrottle, []),
+      worker(ExDNS.Handler.Registry, [])
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/lib/exdns/txt.ex
+++ b/lib/exdns/txt.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Txt do
+defmodule ExDNS.Txt do
   @moduledoc """
   Functions for parsing TXT record content.
   """

--- a/lib/exdns/zone.ex
+++ b/lib/exdns/zone.ex
@@ -1,3 +1,3 @@
-defmodule Exdns.Zone do
+defmodule ExDNS.Zone do
   defstruct name: :undefined, version: :undefined, authority: :undefined, record_count: 0, records: [], records_by_name: [], records_by_type: []
 end

--- a/lib/exdns/zone/loader.ex
+++ b/lib/exdns/zone/loader.ex
@@ -1,4 +1,4 @@
-defmodule Exdns.Zone.Loader do
+defmodule ExDNS.Zone.Loader do
   @moduledoc """
   Logic for loading zone data from a source.
 
@@ -8,15 +8,15 @@ defmodule Exdns.Zone.Loader do
   require Logger
 
   def load_zones do
-    binary = Exdns.Config.zone_file |> File.read!
-    Logger.info("Parsing zones JSON from #{Exdns.Config.zone_file}")
+    binary = ExDNS.Config.zone_file |> File.read!
+    Logger.info("Parsing zones JSON from #{ExDNS.Config.zone_file}")
 
     {:ok, json_zones} = JSX.decode(binary)
     Logger.info("Putting zones into cache")
 
     Enum.each(json_zones, fn(json_zone) ->
-      zone = Exdns.Zone.Parser.json_to_zone(json_zone)
-      Exdns.Zone.Cache.put_zone(zone.name, zone)
+      zone = ExDNS.Zone.Parser.json_to_zone(json_zone)
+      ExDNS.Zone.Cache.put_zone(zone.name, zone)
     end)
     Logger.info("Loaded #{length(json_zones)} zones")
     {:ok, length(json_zones)}

--- a/lib/exdns/zone/parser.ex
+++ b/lib/exdns/zone/parser.ex
@@ -1,9 +1,9 @@
-defmodule Exdns.Zone.Parser do
+defmodule ExDNS.Zone.Parser do
   require Logger
-  require Exdns.Records
+  require ExDNS.Records
  
   @doc """
-  Convert a Map structure from exjxs to an Exdns.Zone instance.
+  Convert a Map structure from exjxs to an ExDNS.Zone instance.
 
   The keys `name` and `records` are required.
 
@@ -22,7 +22,7 @@ defmodule Exdns.Zone.Parser do
       case apply_context_options(r) do
         :pass ->
           case json_record_to_rr(r) do
-            {} -> try_custom_parsers(r, Exdns.Zone.Registry.get_all)
+            {} -> try_custom_parsers(r, ExDNS.Zone.Registry.get_all)
             record -> record
           end
         _ ->
@@ -31,8 +31,8 @@ defmodule Exdns.Zone.Parser do
     end)
 
     records_by_name = build_named_index(records)
-    authorities = Enum.filter(records, Exdns.Records.match_type(:dns_terms_const.dns_type_soa))
-    %Exdns.Zone{
+    authorities = Enum.filter(records, ExDNS.Records.match_type(:dns_terms_const.dns_type_soa))
+    %ExDNS.Zone{
       name: name,
       version: sha,
       records: records,
@@ -72,7 +72,7 @@ defmodule Exdns.Zone.Parser do
     raw_ip = data["ip"]
     case :inet_parse.address(to_char_list(raw_ip)) do
       {:ok, address} ->
-        Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_a, data: Exdns.Records.dns_rrdata_a(ip: address), ttl: ttl)
+        ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_a, data: ExDNS.Records.dns_rrdata_a(ip: address), ttl: ttl)
       {:error, reason} ->
         Logger.error("Failed to parse A record address #{raw_ip}: #{reason}")
         {}
@@ -83,7 +83,7 @@ defmodule Exdns.Zone.Parser do
     raw_ip = data["ip"]
     case :inet_parse.address(to_char_list(raw_ip)) do
       {:ok, address} ->
-        Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_aaaa, data: Exdns.Records.dns_rrdata_aaaa(ip: address), ttl: ttl)
+        ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_aaaa, data: ExDNS.Records.dns_rrdata_aaaa(ip: address), ttl: ttl)
       {:error, reason} ->
         Logger.error("Failed to parse AAAA record address #{raw_ip}: #{reason}")
         {}
@@ -91,61 +91,61 @@ defmodule Exdns.Zone.Parser do
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "CNAME", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_cname(dname: data["dname"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_cname, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_cname(dname: data["dname"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_cname, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "HINFO", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_hinfo(cpu: data["cpu"], os: data["os"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_hinfo, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_hinfo(cpu: data["cpu"], os: data["os"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_hinfo, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "MX", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_mx(exchange: data["exchange"], preference: data["preference"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_mx, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_mx(exchange: data["exchange"], preference: data["preference"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_mx, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "NAPTR", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_naptr(order: data["order"], preference: data["preference"], flags: data["flags"], services: data["services"], regexp: data["regexp"], replacement: data["replacement"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_naptr, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_naptr(order: data["order"], preference: data["preference"], flags: data["flags"], services: data["services"], regexp: data["regexp"], replacement: data["replacement"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_naptr, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "NS", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_ns(dname: data["dname"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_ns, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_ns(dname: data["dname"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_ns, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "RP", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_rp(mbox: data["mbox"], txt: data["txt"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_rp, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_rp(mbox: data["mbox"], txt: data["txt"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_rp, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "SOA", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_soa(mname: data["mname"], rname: data["rname"],
+    rrdata = ExDNS.Records.dns_rrdata_soa(mname: data["mname"], rname: data["rname"],
       serial: data["serial"], refresh: data["refresh"], retry: data["retry"],
       expire: data["expire"], minimum: data["minimum"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa, data: rrdata, ttl: ttl)
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "SPF", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_spf(spf: data["spf"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_spf, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_spf(spf: data["spf"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_spf, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "SRV", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_srv(priority: data["priority"], weight: data["weight"], port: data["port"], target: data["target"])
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_srv, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_srv(priority: data["priority"], weight: data["weight"], port: data["port"], target: data["target"])
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_srv, data: rrdata, ttl: ttl)
   end
 
 
   def json_record_to_rr(%{"name" => name, "type" => "SSHFP", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_sshfp(alg: data["alg"], fp_type: data["fp_type"], fp: Base.decode16!(data["fp"], case: :mixed))
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_sshfp, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_sshfp(alg: data["alg"], fp_type: data["fp_type"], fp: Base.decode16!(data["fp"], case: :mixed))
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_sshfp, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(%{"name" => name, "type" => "TXT", "ttl" => ttl, "data" => data}) do
-    rrdata = Exdns.Records.dns_rrdata_txt(txt: Exdns.Txt.parse(data["txt"]))
-    Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_txt, data: rrdata, ttl: ttl)
+    rrdata = ExDNS.Records.dns_rrdata_txt(txt: ExDNS.Txt.parse(data["txt"]))
+    ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_txt, data: rrdata, ttl: ttl)
   end
 
   def json_record_to_rr(data) do
@@ -164,10 +164,10 @@ defmodule Exdns.Zone.Parser do
 
   defp build_named_index([], index), do: index
   defp build_named_index([r|rest], index) do
-    name = Exdns.Records.dns_rr(r, :name)
+    name = ExDNS.Records.dns_rr(r, :name)
     case Map.get(index, name) do
-      nil -> build_named_index(rest, Map.put(index, Exdns.Zone.Cache.normalize_name(name), [r]))
-      records -> build_named_index(rest, Map.put(index, Exdns.Zone.Cache.normalize_name(name), records ++ [r]))
+      nil -> build_named_index(rest, Map.put(index, ExDNS.Zone.Cache.normalize_name(name), [r]))
+      records -> build_named_index(rest, Map.put(index, ExDNS.Zone.Cache.normalize_name(name), records ++ [r]))
     end
   end
 

--- a/lib/exdns/zone/registry.ex
+++ b/lib/exdns/zone/registry.ex
@@ -1,24 +1,24 @@
-defmodule Exdns.Zone.Registry do
+defmodule ExDNS.Zone.Registry do
   @moduledoc """
   Registry for custom zone parsers. 
   """
 
   use GenServer
 
-  def start_link do
-    GenServer.start_link(__MODULE__, [], name: Exdns.Zone.Registry)
+  def start_link([]) do
+    GenServer.start_link(__MODULE__, [], name: ExDNS.Zone.Registry)
   end
 
   def register(modules) do
-    GenServer.call(Exdns.Zone.Registry, {:register, modules})
+    GenServer.call(ExDNS.Zone.Registry, {:register, modules})
   end
 
   def get_all do
-    GenServer.call(Exdns.Zone.Registry, :get_all)
+    GenServer.call(ExDNS.Zone.Registry, :get_all)
   end
 
   def clear do
-    GenServer.call(Exdns.Zone.Registry, :clear)
+    GenServer.call(ExDNS.Zone.Registry, :clear)
   end
 
   ## Server callbacks

--- a/mix.exs
+++ b/mix.exs
@@ -1,46 +1,41 @@
-defmodule Exdns.Mixfile do
+defmodule ExDNS.MixProject do
   use Mix.Project
 
   def project do
-    [app: :exdns,
-     version: "0.0.2",
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps()]
+    [
+      app: :exdns,
+      version: "0.1.0",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps()
+    ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
+  # Run "mix help compile.app" to learn about applications.
   def application do
-    [applications: [:logger, :folsom], mod: {Exdns, []}, start_phases: [{:post_start, []}]]
+    [
+      extra_applications: [:logger],
+      mod: {ExDNS.Application, []},
+      start_phases: [{:post_start, []}]
+    ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
+  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:folsom, "~> 0.8.3"},
-      {:exjsx, "~> 3.2.0"},
       {:dns_erlang, git: "https://github.com/aetrion/dns_erlang.git", app: false},
-      {:ex_doc, ">= 0.0.0", only: :dev},
-      {:earmark, ">= 0.0.0", only: :dev}
+      {:earmark, "~> 1.2"},
+      {:ex_doc, "~> 0.18"},
+      {:exjsx, "~> 4.0.0"},
+      {:folsom, "~> 0.8"},
     ]
   end
 
   defp description do
     """
-    exdns is an authoritative name server. It is ported from erldns and adapted to the Elixir language.
+    ExDNS is an authoritative name server. It is ported from erldns and adapted to the Elixir language.
     """
   end
 
@@ -51,7 +46,6 @@ defmodule Exdns.Mixfile do
       licenses: ["MIT License"],
       links: %{
         "GitHub" => "https://github.com/dnsimple/exdns",
-        "Documentation" => "https://hexdocs.pm/exdns/0.0.2"
       }
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,12 @@
-%{"asn1ex": {:git, "https://github.com/T0ha/asn1ex.git", "44a63145ee840afb1a1236a12807422cbd286502", [branch: "master"]},
+%{
+  "asn1ex": {:git, "https://github.com/T0ha/asn1ex.git", "44a63145ee840afb1a1236a12807422cbd286502", [branch: "master"]},
   "base32": {:git, "https://github.com/aetrion/base32_erlang.git", "40431a7480176b24863e18b92d9872e54c714df5", [branch: :master]},
-  "bear": {:hex, :bear, "0.8.3", "866002127a97932720a0d475d8582c98ec5fb78db3a18dfe7eaf91594d9024b8", [:rebar3], []},
+  "bear": {:hex, :bear, "0.8.3", "866002127a97932720a0d475d8582c98ec5fb78db3a18dfe7eaf91594d9024b8", [:rebar3], [], "hexpm"},
   "dns_erlang": {:git, "https://github.com/aetrion/dns_erlang.git", "27c84be07561f8f3c00b9ffacd0b4f2d8003cd86", []},
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
-  "folsom": {:hex, :folsom, "0.8.3", "71cff146152fa95e6092e62119f9dc96888660111e7b61853c8fdcf80598a4e0", [:rebar3], [{:bear, "0.8.3", [hex: :bear, optional: false]}]},
-  "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []}}
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
+  "folsom": {:hex, :folsom, "0.8.3", "71cff146152fa95e6092e62119f9dc96888660111e7b61853c8fdcf80598a4e0", [:rebar3], [{:bear, "0.8.3", [repo: "hexpm", hex: :bear, optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
+}

--- a/test/exdns/config_test.exs
+++ b/test/exdns/config_test.exs
@@ -1,37 +1,37 @@
-defmodule Exdns.ConfigTest do
+defmodule ExDNS.ConfigTest do
   use ExUnit.Case, async: true
 
   test "catch exceptions" do
-    assert !Exdns.Config.catch_exceptions?
+    assert !ExDNS.Config.catch_exceptions?
     Application.put_env(:exdns, :catch_exceptions, true)
-    assert Exdns.Config.catch_exceptions?
+    assert ExDNS.Config.catch_exceptions?
     Application.put_env(:exdns, :catch_exceptions, false)
   end
 
   test "use root hints" do
-    assert !Exdns.Config.use_root_hints?
+    assert !ExDNS.Config.use_root_hints?
     Application.put_env(:exdns, :use_root_hints, true)
-    assert Exdns.Config.use_root_hints?
+    assert ExDNS.Config.use_root_hints?
     Application.put_env(:exdns, :use_root_hints, false)
   end
 
   test "provides zone file path" do
-    assert Exdns.Config.zone_file == "priv/test.zones.json"
+    assert ExDNS.Config.zone_file == "priv/test.zones.json"
   end
 
   test "storage type" do
-    assert Exdns.Config.storage_type == Exdns.Storage.EtsStorage
+    assert ExDNS.Config.storage_type == ExDNS.Storage.EtsStorage
   end
 
   test "number of workers" do
-    assert Exdns.Config.num_workers == 16
+    assert ExDNS.Config.num_workers == 16
   end
 
   test "servers" do
-    assert Exdns.Config.servers == []
+    assert ExDNS.Config.servers == []
   end
 
   test "wildcard fallback" do
-    assert !Exdns.Config.wildcard_fallback?
+    assert !ExDNS.Config.wildcard_fallback?
   end
 end

--- a/test/exdns/decoder_test.exs
+++ b/test/exdns/decoder_test.exs
@@ -1,14 +1,14 @@
-defmodule Exdns.DecoderTest do
+defmodule ExDNS.DecoderTest do
   use ExUnit.Case, async: true
-  require Exdns.Records
+  require ExDNS.Records
 
   test "decode empty message" do
-    assert Exdns.Decoder.decode_message(<<>>) == {:formerr, :undefined, ""}
+    assert ExDNS.Decoder.decode_message(<<>>) == {:formerr, :undefined, ""}
   end
 
   test "decode message" do
     bin = <<98, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
-    message = Exdns.Decoder.decode_message(bin)
-    assert Exdns.Records.dns_message(message, :id) > 0
+    message = ExDNS.Decoder.decode_message(bin)
+    assert ExDNS.Records.dns_message(message, :id) > 0
   end
 end

--- a/test/exdns/edns_test.exs
+++ b/test/exdns/edns_test.exs
@@ -1,23 +1,23 @@
-defmodule Exdns.EdnsTest do
-  require Exdns.Records
+defmodule ExDNS.EdnsTest do
+  require ExDNS.Records
 
   use ExUnit.Case, async: true
 
   test "get opts when records are present" do
-    message = Exdns.Records.dns_message
-    assert Exdns.Edns.get_opts(message) == []
+    message = ExDNS.Records.dns_message
+    assert ExDNS.Edns.get_opts(message) == []
   end
 
   test "get opts when an optrr is present" do
-    optrr = Exdns.Records.dns_optrr(dnssec: true)
-    message = Exdns.Records.dns_message(additional: [optrr])
-    assert Exdns.Edns.get_opts(message) == [{:dnssec, true}]
+    optrr = ExDNS.Records.dns_optrr(dnssec: true)
+    message = ExDNS.Records.dns_message(additional: [optrr])
+    assert ExDNS.Edns.get_opts(message) == [{:dnssec, true}]
   end
 
   test "get opts when an optrr is present and other records" do
-    optrr = Exdns.Records.dns_optrr(dnssec: true)
-    rr = Exdns.Records.dns_rr()
-    message = Exdns.Records.dns_message(additional: [optrr, rr])
-    assert Exdns.Edns.get_opts(message) == [{:dnssec, true}]
+    optrr = ExDNS.Records.dns_optrr(dnssec: true)
+    rr = ExDNS.Records.dns_rr()
+    message = ExDNS.Records.dns_message(additional: [optrr, rr])
+    assert ExDNS.Edns.get_opts(message) == [{:dnssec, true}]
   end
 end

--- a/test/exdns/encoder_test.exs
+++ b/test/exdns/encoder_test.exs
@@ -1,10 +1,10 @@
-defmodule Exdns.EncoderTest do
+defmodule ExDNS.EncoderTest do
   use ExUnit.Case, async: true
-  require Exdns.Records
+  require ExDNS.Records
 
   test "encode message" do
-    message = Exdns.Records.dns_message()
-    {false, bin} = Exdns.Encoder.encode_message(message)
-    assert Exdns.Decoder.decode_message(bin) == message 
+    message = ExDNS.Records.dns_message()
+    {false, bin} = ExDNS.Encoder.encode_message(message)
+    assert ExDNS.Decoder.decode_message(bin) == message 
   end
 end

--- a/test/exdns/events_test.exs
+++ b/test/exdns/events_test.exs
@@ -19,7 +19,7 @@ defmodule ExDNS.EventsTest do
   end
 
   test "start the event manager" do
-    ExDNS.Events.start_link()
+    ExDNS.Events.start_link([])
   end
 
   test "add handler and notify" do
@@ -29,7 +29,6 @@ defmodule ExDNS.EventsTest do
   end
 
   test "handle start_severs event" do
-    ExDNS.Server.Supervisor.stop()
     ExDNS.Events.add_handler(ExDNS.Events, [])
     assert GenEvent.call(ExDNS.Events, ExDNS.Events, :get_servers_running) == false
     ExDNS.Events.notify(:start_servers)

--- a/test/exdns/events_test.exs
+++ b/test/exdns/events_test.exs
@@ -1,4 +1,4 @@
-defmodule Exdns.EventsTest do
+defmodule ExDNS.EventsTest do
   use ExUnit.Case
   require Logger
 
@@ -19,20 +19,20 @@ defmodule Exdns.EventsTest do
   end
 
   test "start the event manager" do
-    Exdns.Events.start_link()
+    ExDNS.Events.start_link()
   end
 
   test "add handler and notify" do
-    Exdns.Events.add_handler(Exdns.EventsTest.EventCapture, [])
-    Exdns.Events.notify(:test)
-    assert GenEvent.call(Exdns.Events, Exdns.EventsTest.EventCapture, :messages) == [:test]
+    ExDNS.Events.add_handler(ExDNS.EventsTest.EventCapture, [])
+    ExDNS.Events.notify(:test)
+    assert GenEvent.call(ExDNS.Events, ExDNS.EventsTest.EventCapture, :messages) == [:test]
   end
 
   test "handle start_severs event" do
-    Exdns.Server.Supervisor.stop()
-    Exdns.Events.add_handler(Exdns.Events, [])
-    assert GenEvent.call(Exdns.Events, Exdns.Events, :get_servers_running) == false
-    Exdns.Events.notify(:start_servers)
-    assert GenEvent.call(Exdns.Events, Exdns.Events, :get_servers_running) == true
+    ExDNS.Server.Supervisor.stop()
+    ExDNS.Events.add_handler(ExDNS.Events, [])
+    assert GenEvent.call(ExDNS.Events, ExDNS.Events, :get_servers_running) == false
+    ExDNS.Events.notify(:start_servers)
+    assert GenEvent.call(ExDNS.Events, ExDNS.Events, :get_servers_running) == true
   end
 end

--- a/test/exdns/handler/registry_test.exs
+++ b/test/exdns/handler/registry_test.exs
@@ -1,28 +1,28 @@
-defmodule Exdns.Handler.RegistryTest do
+defmodule ExDNS.Handler.RegistryTest do
   use ExUnit.Case, async: true
 
-  @handler_module Exdns.Handler.RegistryTest.DummyHandler
+  @handler_module ExDNS.Handler.RegistryTest.DummyHandler
 
   defmodule DummyHandler do
   end
 
   test "register handler" do
     record_types = [:dns_terms_const.dns_type_a()]
-    assert Exdns.Handler.Registry.register_handler(record_types, @handler_module)
-    Exdns.Handler.Registry.clear() 
+    assert ExDNS.Handler.Registry.register_handler(record_types, @handler_module)
+    ExDNS.Handler.Registry.clear() 
   end
 
   test "get handlers" do
-    assert [] = Exdns.Handler.Registry.get_handlers()
+    assert [] = ExDNS.Handler.Registry.get_handlers()
   end
 
   test "register and get handler" do
     record_types = [:dns_terms_const.dns_type_a()]
     module = @handler_module
-    Exdns.Handler.Registry.register_handler(record_types, @handler_module)
+    ExDNS.Handler.Registry.register_handler(record_types, @handler_module)
 
-    assert [{^module, ^record_types}] = Exdns.Handler.Registry.get_handlers()
-    Exdns.Handler.Registry.clear() 
+    assert [{^module, ^record_types}] = ExDNS.Handler.Registry.get_handlers()
+    ExDNS.Handler.Registry.clear() 
   end
 end
 

--- a/test/exdns/handler_test.exs
+++ b/test/exdns/handler_test.exs
@@ -1,22 +1,22 @@
-defmodule Exdns.HandlerTest do
+defmodule ExDNS.HandlerTest do
   use ExUnit.Case, async: true
-  require Exdns.Records
+  require ExDNS.Records
 
   test "handle trailing garbage" do
-    message = Exdns.Records.dns_message
+    message = ExDNS.Records.dns_message
     context = {:unknown, :host}
-    Exdns.Handler.handle({:trailing_garbage, message, :unknown}, context)
+    ExDNS.Handler.handle({:trailing_garbage, message, :unknown}, context)
   end
 
   test "handle DNS message" do
-    message = Exdns.Records.dns_message
+    message = ExDNS.Records.dns_message
     context = {:unknown, :host}
-    Exdns.Handler.handle(message, context)
+    ExDNS.Handler.handle(message, context)
   end
 
   test "handle bad message" do
     message = :message
     context = {:unknown, :host}
-    Exdns.Handler.handle(message, context)
+    ExDNS.Handler.handle(message, context)
   end
 end

--- a/test/exdns/packet_cache_test.exs
+++ b/test/exdns/packet_cache_test.exs
@@ -1,43 +1,43 @@
-defmodule Exdns.PacketCacheTest do
+defmodule ExDNS.PacketCacheTest do
   use ExUnit.Case, async: false
-  require Exdns.Records
+  require ExDNS.Records
 
   test "get question not in cache" do
-    assert Exdns.PacketCache.clear()
-    question = Exdns.Records.dns_query()
-    assert Exdns.PacketCache.get(question) == {:error, :cache_miss}
+    assert ExDNS.PacketCache.clear()
+    question = ExDNS.Records.dns_query()
+    assert ExDNS.PacketCache.get(question) == {:error, :cache_miss}
   end
 
   test "get question in cache" do
-    question = Exdns.Records.dns_query()
-    message = Exdns.Records.dns_message()
-    assert Exdns.PacketCache.put(question, message)
-    assert Exdns.PacketCache.get(question) == {:ok, message}
-    assert Exdns.PacketCache.get(question, {1, 2, 3, 4}) == {:ok, message}
+    question = ExDNS.Records.dns_query()
+    message = ExDNS.Records.dns_message()
+    assert ExDNS.PacketCache.put(question, message)
+    assert ExDNS.PacketCache.get(question) == {:ok, message}
+    assert ExDNS.PacketCache.get(question, {1, 2, 3, 4}) == {:ok, message}
   end
 
   test "get question in cache that is expired" do
-    question = Exdns.Records.dns_query()
-    message = Exdns.Records.dns_message()
-    assert Exdns.Storage.insert(:packet_cache, {question, {message, 0}})
-    assert Exdns.PacketCache.get(question) == {:error, :cache_expired}
+    question = ExDNS.Records.dns_query()
+    message = ExDNS.Records.dns_message()
+    assert ExDNS.Storage.insert(:packet_cache, {question, {message, 0}})
+    assert ExDNS.PacketCache.get(question) == {:error, :cache_expired}
   end
 
   test "sweep the cache" do
-    question = Exdns.Records.dns_query()
-    message = Exdns.Records.dns_message()
-    assert Exdns.Storage.insert(:packet_cache, {question, {message, 0}})
-    assert Exdns.PacketCache.get(question) == {:error, :cache_expired}
-    Exdns.PacketCache.sweep()
-    assert Exdns.PacketCache.get(question) == {:error, :cache_miss}
+    question = ExDNS.Records.dns_query()
+    message = ExDNS.Records.dns_message()
+    assert ExDNS.Storage.insert(:packet_cache, {question, {message, 0}})
+    assert ExDNS.PacketCache.get(question) == {:error, :cache_expired}
+    ExDNS.PacketCache.sweep()
+    assert ExDNS.PacketCache.get(question) == {:error, :cache_miss}
   end
 
   test "clear the cache" do
-    question = Exdns.Records.dns_query()
-    message = Exdns.Records.dns_message()
-    assert Exdns.PacketCache.put(question, message)
-    assert Exdns.PacketCache.get(question) == {:ok, message}
-    assert Exdns.PacketCache.clear
-    assert Exdns.PacketCache.get(question) == {:error, :cache_miss}
+    question = ExDNS.Records.dns_query()
+    message = ExDNS.Records.dns_message()
+    assert ExDNS.PacketCache.put(question, message)
+    assert ExDNS.PacketCache.get(question) == {:ok, message}
+    assert ExDNS.PacketCache.clear
+    assert ExDNS.PacketCache.get(question) == {:error, :cache_miss}
   end
 end

--- a/test/exdns/query_throttle_test.exs
+++ b/test/exdns/query_throttle_test.exs
@@ -1,45 +1,45 @@
-defmodule Exdns.QueryThrottleTest do
+defmodule ExDNS.QueryThrottleTest do
   use ExUnit.Case, async: false
-  require Exdns.Records
+  require ExDNS.Records
   require Logger
 
   @ip {1, 2, 3, 4}
 
   setup do
-    Exdns.QueryThrottle.clear()
+    ExDNS.QueryThrottle.clear()
   end
 
   test "throttle does not throttle TCP" do
-    assert Exdns.QueryThrottle.throttle(test_message(:dns_terms_const.dns_type_any), {:tcp, @ip}) == :ok
-    Exdns.QueryThrottle.clear()
+    assert ExDNS.QueryThrottle.throttle(test_message(:dns_terms_const.dns_type_any), {:tcp, @ip}) == :ok
+    ExDNS.QueryThrottle.clear()
   end
 
   test "throttle allows 1 UDP ANY queries" do
-    assert Exdns.QueryThrottle.throttle(test_message(:dns_terms_const.dns_type_any), {:udp, @ip}) == {:ok, @ip, 1}
+    assert ExDNS.QueryThrottle.throttle(test_message(:dns_terms_const.dns_type_any), {:udp, @ip}) == {:ok, @ip, 1}
   end
 
   test "throttle throttles 2 UDP ANY queries" do
     message = test_message(:dns_terms_const.dns_type_any)
-    assert Exdns.QueryThrottle.throttle(message, {:udp, @ip}) == {:ok, @ip, 1}
-    assert Exdns.QueryThrottle.throttle(message, {:udp, @ip}) == {:throttled, @ip, 2}
+    assert ExDNS.QueryThrottle.throttle(message, {:udp, @ip}) == {:ok, @ip, 1}
+    assert ExDNS.QueryThrottle.throttle(message, {:udp, @ip}) == {:throttled, @ip, 2}
   end
 
   test "throttle never throttles UDP non-ANY queries" do
-    assert Exdns.QueryThrottle.throttle(test_message(:dns_terms_const.dns_type_a), {:udp, @ip}) == :ok
+    assert ExDNS.QueryThrottle.throttle(test_message(:dns_terms_const.dns_type_a), {:udp, @ip}) == :ok
   end
 
   test "sweep the throttle" do
     message = test_message(:dns_terms_const.dns_type_any)
-    Exdns.Storage.insert(:host_throttle, {@ip, {10, Exdns.timestamp()}})
-    assert Exdns.QueryThrottle.throttle(message, {:udp, @ip}) == {:throttled, @ip, 11}
-    Exdns.Storage.insert(:host_throttle, {@ip, {10, Exdns.timestamp() - 61}})
-    Exdns.QueryThrottle.sweep()
-    assert Exdns.QueryThrottle.throttle(message, {:udp, @ip}) == {:ok, @ip, 1}
+    ExDNS.Storage.insert(:host_throttle, {@ip, {10, ExDNS.timestamp()}})
+    assert ExDNS.QueryThrottle.throttle(message, {:udp, @ip}) == {:throttled, @ip, 11}
+    ExDNS.Storage.insert(:host_throttle, {@ip, {10, ExDNS.timestamp() - 61}})
+    ExDNS.QueryThrottle.sweep()
+    assert ExDNS.QueryThrottle.throttle(message, {:udp, @ip}) == {:ok, @ip, 1}
   end
 
   defp test_message(question_type) do
-    question = Exdns.Records.dns_query()
-    question = Exdns.Records.dns_query(question, type: question_type)
-    Exdns.Records.dns_message(Exdns.Records.dns_message(), questions: [question])
+    question = ExDNS.Records.dns_query()
+    question = ExDNS.Records.dns_query(question, type: question_type)
+    ExDNS.Records.dns_message(ExDNS.Records.dns_message(), questions: [question])
   end
 end

--- a/test/exdns/records_test.exs
+++ b/test/exdns/records_test.exs
@@ -1,197 +1,197 @@
-defmodule Exdns.RecordsTest do
+defmodule ExDNS.RecordsTest do
   use ExUnit.Case, async: true
-  require Exdns.Records
+  require ExDNS.Records
 
   # Records
 
   test "dns message construction" do
-    message = Exdns.Records.dns_message()
-    assert Exdns.Records.dns_message(message, :id) != nil
-    assert Exdns.Records.dns_message(message, :qr) == false
-    assert Exdns.Records.dns_message(message, :oc) == :dns_terms_const.dns_opcode_query
-    assert Exdns.Records.dns_message(message, :aa) == false
-    assert Exdns.Records.dns_message(message, :tc) == false
-    assert Exdns.Records.dns_message(message, :rd) == false
-    assert Exdns.Records.dns_message(message, :ra) == false
-    assert Exdns.Records.dns_message(message, :ad) == false
-    assert Exdns.Records.dns_message(message, :cd) == false
-    assert Exdns.Records.dns_message(message, :rc) == :dns_terms_const.dns_rcode_noerror
-    assert Exdns.Records.dns_message(message, :qc) == 0
-    assert Exdns.Records.dns_message(message, :anc) == 0
-    assert Exdns.Records.dns_message(message, :auc) == 0
-    assert Exdns.Records.dns_message(message, :adc) == 0
-    assert Exdns.Records.dns_message(message, :questions) == []
-    assert Exdns.Records.dns_message(message, :answers) == []
-    assert Exdns.Records.dns_message(message, :authority) == []
-    assert Exdns.Records.dns_message(message, :additional) == []
+    message = ExDNS.Records.dns_message()
+    assert ExDNS.Records.dns_message(message, :id) != nil
+    assert ExDNS.Records.dns_message(message, :qr) == false
+    assert ExDNS.Records.dns_message(message, :oc) == :dns_terms_const.dns_opcode_query
+    assert ExDNS.Records.dns_message(message, :aa) == false
+    assert ExDNS.Records.dns_message(message, :tc) == false
+    assert ExDNS.Records.dns_message(message, :rd) == false
+    assert ExDNS.Records.dns_message(message, :ra) == false
+    assert ExDNS.Records.dns_message(message, :ad) == false
+    assert ExDNS.Records.dns_message(message, :cd) == false
+    assert ExDNS.Records.dns_message(message, :rc) == :dns_terms_const.dns_rcode_noerror
+    assert ExDNS.Records.dns_message(message, :qc) == 0
+    assert ExDNS.Records.dns_message(message, :anc) == 0
+    assert ExDNS.Records.dns_message(message, :auc) == 0
+    assert ExDNS.Records.dns_message(message, :adc) == 0
+    assert ExDNS.Records.dns_message(message, :questions) == []
+    assert ExDNS.Records.dns_message(message, :answers) == []
+    assert ExDNS.Records.dns_message(message, :authority) == []
+    assert ExDNS.Records.dns_message(message, :additional) == []
   end
 
   test "dns query construction" do
-    question = Exdns.Records.dns_query()
-    assert Exdns.Records.dns_query(question, :name) == :undefined
-    assert Exdns.Records.dns_query(question, :class) == :dns_terms_const.dns_class_in()
-    assert Exdns.Records.dns_query(question, :type) == :undefined
+    question = ExDNS.Records.dns_query()
+    assert ExDNS.Records.dns_query(question, :name) == :undefined
+    assert ExDNS.Records.dns_query(question, :class) == :dns_terms_const.dns_class_in()
+    assert ExDNS.Records.dns_query(question, :type) == :undefined
   end
 
   test "dns resource record construction" do
-    rr = Exdns.Records.dns_rr()
-    assert Exdns.Records.dns_rr(rr, :name) == :undefined
-    assert Exdns.Records.dns_rr(rr, :class) == :dns_terms_const.dns_class_in()
-    assert Exdns.Records.dns_rr(rr, :type) == :undefined
-    assert Exdns.Records.dns_rr(rr, :ttl) == 0
-    assert Exdns.Records.dns_rr(rr, :data) == :undefined
+    rr = ExDNS.Records.dns_rr()
+    assert ExDNS.Records.dns_rr(rr, :name) == :undefined
+    assert ExDNS.Records.dns_rr(rr, :class) == :dns_terms_const.dns_class_in()
+    assert ExDNS.Records.dns_rr(rr, :type) == :undefined
+    assert ExDNS.Records.dns_rr(rr, :ttl) == 0
+    assert ExDNS.Records.dns_rr(rr, :data) == :undefined
   end
 
   test "dns resource record data type A construction" do
-    rrdata = Exdns.Records.dns_rrdata_a()
-    assert Exdns.Records.dns_rrdata_a(rrdata, :ip) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_a()
+    assert ExDNS.Records.dns_rrdata_a(rrdata, :ip) == :undefined
   end
 
   test "dns resource record data type AAAA construction" do
-    rrdata = Exdns.Records.dns_rrdata_aaaa()
-    assert Exdns.Records.dns_rrdata_aaaa(rrdata, :ip) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_aaaa()
+    assert ExDNS.Records.dns_rrdata_aaaa(rrdata, :ip) == :undefined
   end
 
   test "dns resource record data type CNAME construction" do
-    rrdata = Exdns.Records.dns_rrdata_cname()
-    assert Exdns.Records.dns_rrdata_cname(rrdata, :dname) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_cname()
+    assert ExDNS.Records.dns_rrdata_cname(rrdata, :dname) == :undefined
   end
 
   test "dns resource record data type HINFO construction" do
-    rrdata = Exdns.Records.dns_rrdata_hinfo()
-    assert Exdns.Records.dns_rrdata_hinfo(rrdata, :cpu) == :undefined
-    assert Exdns.Records.dns_rrdata_hinfo(rrdata, :os) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_hinfo()
+    assert ExDNS.Records.dns_rrdata_hinfo(rrdata, :cpu) == :undefined
+    assert ExDNS.Records.dns_rrdata_hinfo(rrdata, :os) == :undefined
   end
 
   test "dns resource record data type MX construction" do
-    rrdata = Exdns.Records.dns_rrdata_mx()
-    assert Exdns.Records.dns_rrdata_mx(rrdata, :exchange) == :undefined
-    assert Exdns.Records.dns_rrdata_mx(rrdata, :preference) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_mx()
+    assert ExDNS.Records.dns_rrdata_mx(rrdata, :exchange) == :undefined
+    assert ExDNS.Records.dns_rrdata_mx(rrdata, :preference) == :undefined
   end
 
   test "dns resource record data type NAPTR construction" do
-    rrdata = Exdns.Records.dns_rrdata_naptr()
-    assert Exdns.Records.dns_rrdata_naptr(rrdata, :order) == :undefined
-    assert Exdns.Records.dns_rrdata_naptr(rrdata, :preference) == :undefined
-    assert Exdns.Records.dns_rrdata_naptr(rrdata, :flags) == :undefined
-    assert Exdns.Records.dns_rrdata_naptr(rrdata, :services) == :undefined
-    assert Exdns.Records.dns_rrdata_naptr(rrdata, :regexp) == :undefined
-    assert Exdns.Records.dns_rrdata_naptr(rrdata, :replacement) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_naptr()
+    assert ExDNS.Records.dns_rrdata_naptr(rrdata, :order) == :undefined
+    assert ExDNS.Records.dns_rrdata_naptr(rrdata, :preference) == :undefined
+    assert ExDNS.Records.dns_rrdata_naptr(rrdata, :flags) == :undefined
+    assert ExDNS.Records.dns_rrdata_naptr(rrdata, :services) == :undefined
+    assert ExDNS.Records.dns_rrdata_naptr(rrdata, :regexp) == :undefined
+    assert ExDNS.Records.dns_rrdata_naptr(rrdata, :replacement) == :undefined
   end
 
   test "dns resource record data type NS construction" do
-    rrdata = Exdns.Records.dns_rrdata_ns()
-    assert Exdns.Records.dns_rrdata_ns(rrdata, :dname) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_ns()
+    assert ExDNS.Records.dns_rrdata_ns(rrdata, :dname) == :undefined
   end
 
   test "dns resource record data type PTR construction" do
-    rrdata = Exdns.Records.dns_rrdata_ptr()
-    assert Exdns.Records.dns_rrdata_ptr(rrdata, :dname) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_ptr()
+    assert ExDNS.Records.dns_rrdata_ptr(rrdata, :dname) == :undefined
   end
 
   test "dns resource record data type RP construction" do
-    rrdata = Exdns.Records.dns_rrdata_rp()
-    assert Exdns.Records.dns_rrdata_rp(rrdata, :mbox) == :undefined
-    assert Exdns.Records.dns_rrdata_rp(rrdata, :txt) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_rp()
+    assert ExDNS.Records.dns_rrdata_rp(rrdata, :mbox) == :undefined
+    assert ExDNS.Records.dns_rrdata_rp(rrdata, :txt) == :undefined
   end
 
   test "dns resource record data type SOA construction" do
-    rrdata = Exdns.Records.dns_rrdata_soa()
-    assert Exdns.Records.dns_rrdata_soa(rrdata, :mname) == :undefined
-    assert Exdns.Records.dns_rrdata_soa(rrdata, :rname) == :undefined
-    assert Exdns.Records.dns_rrdata_soa(rrdata, :serial) == :undefined
-    assert Exdns.Records.dns_rrdata_soa(rrdata, :refresh) == :undefined
-    assert Exdns.Records.dns_rrdata_soa(rrdata, :retry) == :undefined
-    assert Exdns.Records.dns_rrdata_soa(rrdata, :expire) == :undefined
-    assert Exdns.Records.dns_rrdata_soa(rrdata, :minimum) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_soa()
+    assert ExDNS.Records.dns_rrdata_soa(rrdata, :mname) == :undefined
+    assert ExDNS.Records.dns_rrdata_soa(rrdata, :rname) == :undefined
+    assert ExDNS.Records.dns_rrdata_soa(rrdata, :serial) == :undefined
+    assert ExDNS.Records.dns_rrdata_soa(rrdata, :refresh) == :undefined
+    assert ExDNS.Records.dns_rrdata_soa(rrdata, :retry) == :undefined
+    assert ExDNS.Records.dns_rrdata_soa(rrdata, :expire) == :undefined
+    assert ExDNS.Records.dns_rrdata_soa(rrdata, :minimum) == :undefined
   end
 
   test "dns resource record data type SPF construction" do
-    rrdata = Exdns.Records.dns_rrdata_spf()
-    assert Exdns.Records.dns_rrdata_spf(rrdata, :spf) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_spf()
+    assert ExDNS.Records.dns_rrdata_spf(rrdata, :spf) == :undefined
   end
 
   test "dns resource record data type SRV construction" do
-    rrdata = Exdns.Records.dns_rrdata_srv()
-    assert Exdns.Records.dns_rrdata_srv(rrdata, :priority) == :undefined
-    assert Exdns.Records.dns_rrdata_srv(rrdata, :weight) == :undefined
-    assert Exdns.Records.dns_rrdata_srv(rrdata, :port) == :undefined
-    assert Exdns.Records.dns_rrdata_srv(rrdata, :target) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_srv()
+    assert ExDNS.Records.dns_rrdata_srv(rrdata, :priority) == :undefined
+    assert ExDNS.Records.dns_rrdata_srv(rrdata, :weight) == :undefined
+    assert ExDNS.Records.dns_rrdata_srv(rrdata, :port) == :undefined
+    assert ExDNS.Records.dns_rrdata_srv(rrdata, :target) == :undefined
   end
 
   test "dns resource record data type SSHFP construction" do
-    rrdata = Exdns.Records.dns_rrdata_sshfp()
-    assert Exdns.Records.dns_rrdata_sshfp(rrdata, :alg) == :undefined
-    assert Exdns.Records.dns_rrdata_sshfp(rrdata, :fp_type) == :undefined
-    assert Exdns.Records.dns_rrdata_sshfp(rrdata, :fp) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_sshfp()
+    assert ExDNS.Records.dns_rrdata_sshfp(rrdata, :alg) == :undefined
+    assert ExDNS.Records.dns_rrdata_sshfp(rrdata, :fp_type) == :undefined
+    assert ExDNS.Records.dns_rrdata_sshfp(rrdata, :fp) == :undefined
   end
 
   test "dns resource record data type TXT construction" do
-    rrdata = Exdns.Records.dns_rrdata_txt()
-    assert Exdns.Records.dns_rrdata_txt(rrdata, :txt) == :undefined
+    rrdata = ExDNS.Records.dns_rrdata_txt()
+    assert ExDNS.Records.dns_rrdata_txt(rrdata, :txt) == :undefined
   end
 
   # Utility functions
 
   test "minimum soa TTL" do
-    record = Exdns.Records.dns_rr(ttl: 10)
-    data = Exdns.Records.dns_rrdata_soa(minimum: 20)
-    assert Exdns.Records.dns_rr(Exdns.Records.minimum_soa_ttl(record, data), :ttl) == 10
+    record = ExDNS.Records.dns_rr(ttl: 10)
+    data = ExDNS.Records.dns_rrdata_soa(minimum: 20)
+    assert ExDNS.Records.dns_rr(ExDNS.Records.minimum_soa_ttl(record, data), :ttl) == 10
 
-    data = Exdns.Records.dns_rrdata_soa(minimum: 5)
-    assert Exdns.Records.dns_rr(Exdns.Records.minimum_soa_ttl(record, data), :ttl) == 5
+    data = ExDNS.Records.dns_rrdata_soa(minimum: 5)
+    assert ExDNS.Records.dns_rr(ExDNS.Records.minimum_soa_ttl(record, data), :ttl) == 5
   end
 
   # Matchers
 
   test "match name" do
     name = "example.com"
-    soa_rr = Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa)
-    a_rr = Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_a)
-    cname_rr = Exdns.Records.dns_rr(name: "www.#{name}", type: :dns_terms_const.dns_type_cname)
-    assert Enum.filter([soa_rr, a_rr, cname_rr], Exdns.Records.match_name(name)) == [soa_rr, a_rr]
+    soa_rr = ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa)
+    a_rr = ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_a)
+    cname_rr = ExDNS.Records.dns_rr(name: "www.#{name}", type: :dns_terms_const.dns_type_cname)
+    assert Enum.filter([soa_rr, a_rr, cname_rr], ExDNS.Records.match_name(name)) == [soa_rr, a_rr]
   end
 
   test "match type" do
-    soa_rr = Exdns.Records.dns_rr(type: :dns_terms_const.dns_type_soa)
-    a_rr = Exdns.Records.dns_rr(type: :dns_terms_const.dns_type_a)
-    assert Enum.filter([soa_rr, a_rr], Exdns.Records.match_type(:dns_terms_const.dns_type_soa)) == [soa_rr]
+    soa_rr = ExDNS.Records.dns_rr(type: :dns_terms_const.dns_type_soa)
+    a_rr = ExDNS.Records.dns_rr(type: :dns_terms_const.dns_type_a)
+    assert Enum.filter([soa_rr, a_rr], ExDNS.Records.match_type(:dns_terms_const.dns_type_soa)) == [soa_rr]
   end
 
   test "match name and type" do
     name = "example.com"
-    soa_rr = Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa)
-    a_rr = Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_a)
-    a_rr2 = Exdns.Records.dns_rr(name: "www.#{name}", type: :dns_terms_const.dns_type_a)
-    assert Enum.filter([soa_rr, a_rr, a_rr2], Exdns.Records.match_name_and_type(name, :dns_terms_const.dns_type_a)) == [a_rr]
+    soa_rr = ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa)
+    a_rr = ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_a)
+    a_rr2 = ExDNS.Records.dns_rr(name: "www.#{name}", type: :dns_terms_const.dns_type_a)
+    assert Enum.filter([soa_rr, a_rr, a_rr2], ExDNS.Records.match_name_and_type(name, :dns_terms_const.dns_type_a)) == [a_rr]
   end
 
   test "match types" do
-    soa_rr = Exdns.Records.dns_rr(type: :dns_terms_const.dns_type_soa)
-    a_rr = Exdns.Records.dns_rr(type: :dns_terms_const.dns_type_a)
-    cname_rr = Exdns.Records.dns_rr(type: :dns_terms_const.dns_type_cname)
+    soa_rr = ExDNS.Records.dns_rr(type: :dns_terms_const.dns_type_soa)
+    a_rr = ExDNS.Records.dns_rr(type: :dns_terms_const.dns_type_a)
+    cname_rr = ExDNS.Records.dns_rr(type: :dns_terms_const.dns_type_cname)
     types = [:dns_terms_const.dns_type_a, :dns_terms_const.dns_type_cname]
-    assert Enum.filter([soa_rr, a_rr, cname_rr], Exdns.Records.match_types(types)) == [a_rr, cname_rr]
+    assert Enum.filter([soa_rr, a_rr, cname_rr], ExDNS.Records.match_types(types)) == [a_rr, cname_rr]
   end
 
   test "match wildcard" do
     name = "example.com"
-    rr = Exdns.Records.dns_rr(name: name)
-    wildcard_rr = Exdns.Records.dns_rr(name: "*.#{name}")
-    assert Enum.filter([rr, wildcard_rr], Exdns.Records.match_wildcard()) == [wildcard_rr]
+    rr = ExDNS.Records.dns_rr(name: name)
+    wildcard_rr = ExDNS.Records.dns_rr(name: "*.#{name}")
+    assert Enum.filter([rr, wildcard_rr], ExDNS.Records.match_wildcard()) == [wildcard_rr]
   end
 
   test "match delegation" do
     name = "ns1.example.com"
-    rr = Exdns.Records.dns_rr(data: Exdns.Records.dns_rrdata_ns(dname: name))
-    assert Enum.all?([rr], Exdns.Records.match_delegation(name))
+    rr = ExDNS.Records.dns_rr(data: ExDNS.Records.dns_rrdata_ns(dname: name))
+    assert Enum.all?([rr], ExDNS.Records.match_delegation(name))
   end
 
   # Replacement functions
 
   test "replace name" do
-    rr = Exdns.Records.dns_rr(name: "foo")
-    assert Enum.map([rr], Exdns.Records.replace_name("bar")) == [Exdns.Records.dns_rr(name: "bar")]
+    rr = ExDNS.Records.dns_rr(name: "foo")
+    assert Enum.map([rr], ExDNS.Records.replace_name("bar")) == [ExDNS.Records.dns_rr(name: "bar")]
   end
 
 end

--- a/test/exdns/resolver_test.exs
+++ b/test/exdns/resolver_test.exs
@@ -1,126 +1,126 @@
-defmodule Exdns.ResolverTest do
+defmodule ExDNS.ResolverTest do
   use ExUnit.Case, async: true
   require Logger
-  require Exdns.Records
+  require ExDNS.Records
 
   test "resolve with no questions" do
-    message = Exdns.Records.dns_message()
-    assert Exdns.Resolver.resolve(message, :authority, :host) == message
+    message = ExDNS.Records.dns_message()
+    assert ExDNS.Resolver.resolve(message, :authority, :host) == message
   end
 
   test "resolve with one question for type A" do
-    {:ok, zone} = Exdns.Zone.Cache.get_zone("example.com")
+    {:ok, zone} = ExDNS.Zone.Cache.get_zone("example.com")
     assert zone.authority != :undefined
-    question = Exdns.Records.dns_query(name: "outpost.example.com", type: :dns_terms_const.dns_type_a)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, [zone.authority], :host)
-    assert length(Exdns.Records.dns_message(answer, :answers)) > 0
+    question = ExDNS.Records.dns_query(name: "outpost.example.com", type: :dns_terms_const.dns_type_a)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, [zone.authority], :host)
+    assert length(ExDNS.Records.dns_message(answer, :answers)) > 0
   end
 
   test "resolve with one question for type CNAME" do
-    {:ok, zone} = Exdns.Zone.Cache.get_zone("example.com")
+    {:ok, zone} = ExDNS.Zone.Cache.get_zone("example.com")
     assert zone.authority != :undefined
-    question = Exdns.Records.dns_query(name: "www.example.com", type: :dns_terms_const.dns_type_cname)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, [zone.authority], :host)
-    assert length(Exdns.Records.dns_message(answer, :answers)) > 0
+    question = ExDNS.Records.dns_query(name: "www.example.com", type: :dns_terms_const.dns_type_cname)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, [zone.authority], :host)
+    assert length(ExDNS.Records.dns_message(answer, :answers)) > 0
   end
 
   test "resolve with one question for type SOA" do
-    {:ok, zone} = Exdns.Zone.Cache.get_zone("example.com")
+    {:ok, zone} = ExDNS.Zone.Cache.get_zone("example.com")
     assert zone.authority != :undefined
-    question = Exdns.Records.dns_query(name: "example.com", type: :dns_terms_const.dns_type_soa)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, [zone.authority], :host)
-    assert length(Exdns.Records.dns_message(answer, :answers)) > 0
+    question = ExDNS.Records.dns_query(name: "example.com", type: :dns_terms_const.dns_type_soa)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, [zone.authority], :host)
+    assert length(ExDNS.Records.dns_message(answer, :answers)) > 0
   end
 
   # Step 3 tests
   test "test resolve when not authoritative" do
-    question = Exdns.Records.dns_query(name: "notfound.com", type: :dns_terms_const.dns_type_a)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, [], :host)
-    assert Exdns.Records.dns_message(answer, :aa)
-    assert Exdns.Records.dns_message(answer, :rc) == :dns_terms_const.dns_rcode_noerror
-    assert length(Exdns.Records.dns_message(answer, :answers)) == 0
-    assert length(Exdns.Records.dns_message(answer, :authority)) == 0
-    assert length(Exdns.Records.dns_message(answer, :additional)) == 0
+    question = ExDNS.Records.dns_query(name: "notfound.com", type: :dns_terms_const.dns_type_a)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, [], :host)
+    assert ExDNS.Records.dns_message(answer, :aa)
+    assert ExDNS.Records.dns_message(answer, :rc) == :dns_terms_const.dns_rcode_noerror
+    assert length(ExDNS.Records.dns_message(answer, :answers)) == 0
+    assert length(ExDNS.Records.dns_message(answer, :authority)) == 0
+    assert length(ExDNS.Records.dns_message(answer, :additional)) == 0
   end
 
   test "test resolve when not authoritative and returning root hints" do
     Application.put_env(:exdns, :use_root_hints, true)
-    question = Exdns.Records.dns_query(name: "notfound.com", type: :dns_terms_const.dns_type_a)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, [], :host)
-    assert Exdns.Records.dns_message(answer, :aa)
-    assert Exdns.Records.dns_message(answer, :rc) == :dns_terms_const.dns_rcode_noerror
-    assert length(Exdns.Records.dns_message(answer, :answers)) == 0
-    assert length(Exdns.Records.dns_message(answer, :authority)) > 0
-    assert length(Exdns.Records.dns_message(answer, :additional)) > 0
+    question = ExDNS.Records.dns_query(name: "notfound.com", type: :dns_terms_const.dns_type_a)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, [], :host)
+    assert ExDNS.Records.dns_message(answer, :aa)
+    assert ExDNS.Records.dns_message(answer, :rc) == :dns_terms_const.dns_rcode_noerror
+    assert length(ExDNS.Records.dns_message(answer, :answers)) == 0
+    assert length(ExDNS.Records.dns_message(answer, :authority)) > 0
+    assert length(ExDNS.Records.dns_message(answer, :additional)) > 0
     Application.put_env(:exdns, :use_root_hints, false)
   end
 
   test "test any wildcard" do
-    {:ok, zone} = Exdns.Zone.Cache.get_zone("wtest.com")
+    {:ok, zone} = ExDNS.Zone.Cache.get_zone("wtest.com")
     assert zone.authority != :undefined
-    question = Exdns.Records.dns_query(name: "fwejfiwerrfj.something.wtest.com", type: :dns_terms_const.dns_type_a)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, zone.authority, :host)
-    assert Exdns.Records.dns_message(answer, :aa)
-    assert length(Exdns.Records.dns_message(answer, :answers)) > 0
-    assert length(Exdns.Records.dns_message(answer, :authority)) == 0
-    assert length(Exdns.Records.dns_message(answer, :additional)) == 0
+    question = ExDNS.Records.dns_query(name: "fwejfiwerrfj.something.wtest.com", type: :dns_terms_const.dns_type_a)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, zone.authority, :host)
+    assert ExDNS.Records.dns_message(answer, :aa)
+    assert length(ExDNS.Records.dns_message(answer, :answers)) > 0
+    assert length(ExDNS.Records.dns_message(answer, :authority)) == 0
+    assert length(ExDNS.Records.dns_message(answer, :additional)) == 0
   end
 
   test "cname and wildcard at root" do
-    {:ok, zone} = Exdns.Zone.Cache.get_zone("wtest.com")
+    {:ok, zone} = ExDNS.Zone.Cache.get_zone("wtest.com")
     assert zone.authority != :undefined
-    question = Exdns.Records.dns_query(name: "secure.wtest.com", type: :dns_terms_const.dns_type_a)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, zone.authority, :host)
-    assert Exdns.Records.dns_message(answer, :aa)
-    assert length(Exdns.Records.dns_message(answer, :answers)) == 0
-    assert length(Exdns.Records.dns_message(answer, :authority)) > 0
-    assert length(Exdns.Records.dns_message(answer, :additional)) == 0
+    question = ExDNS.Records.dns_query(name: "secure.wtest.com", type: :dns_terms_const.dns_type_a)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, zone.authority, :host)
+    assert ExDNS.Records.dns_message(answer, :aa)
+    assert length(ExDNS.Records.dns_message(answer, :answers)) == 0
+    assert length(ExDNS.Records.dns_message(answer, :authority)) > 0
+    assert length(ExDNS.Records.dns_message(answer, :additional)) == 0
   end
 
   test "cname and wildcard but no correct type" do
-    {:ok, zone} = Exdns.Zone.Cache.get_zone("test.com")
+    {:ok, zone} = ExDNS.Zone.Cache.get_zone("test.com")
     assert zone.authority != :undefined
-    question = Exdns.Records.dns_query(name: "yo.test.test.com", type: :dns_terms_const.dns_type_aaaa)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, zone.authority, :host)
-    assert Exdns.Records.dns_message(answer, :aa)
-    assert length(Exdns.Records.dns_message(answer, :answers)) > 0
-    assert length(Exdns.Records.dns_message(answer, :authority)) > 0
-    assert length(Exdns.Records.dns_message(answer, :additional)) == 0
+    question = ExDNS.Records.dns_query(name: "yo.test.test.com", type: :dns_terms_const.dns_type_aaaa)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, zone.authority, :host)
+    assert ExDNS.Records.dns_message(answer, :aa)
+    assert length(ExDNS.Records.dns_message(answer, :answers)) > 0
+    assert length(ExDNS.Records.dns_message(answer, :authority)) > 0
+    assert length(ExDNS.Records.dns_message(answer, :additional)) == 0
   end
 
   test "same record only appears in answer set once" do
-    {:ok, zone} = Exdns.Zone.Cache.get_zone("example.com")
+    {:ok, zone} = ExDNS.Zone.Cache.get_zone("example.com")
     assert zone.authority != :undefined
-    question = Exdns.Records.dns_query(name: "double.example.com", type: :dns_terms_const.dns_type_a)
-    message = Exdns.Records.dns_message(questions: [question])
-    answer = Exdns.Resolver.resolve(message, zone.authority, :host)
-    assert Exdns.Records.dns_message(answer, :aa)
-    assert length(Exdns.Records.dns_message(answer, :answers)) == 1
-    assert length(Exdns.Records.dns_message(answer, :authority)) == 0
-    assert length(Exdns.Records.dns_message(answer, :additional)) == 0
+    question = ExDNS.Records.dns_query(name: "double.example.com", type: :dns_terms_const.dns_type_a)
+    message = ExDNS.Records.dns_message(questions: [question])
+    answer = ExDNS.Resolver.resolve(message, zone.authority, :host)
+    assert ExDNS.Records.dns_message(answer, :aa)
+    assert length(ExDNS.Records.dns_message(answer, :answers)) == 1
+    assert length(ExDNS.Records.dns_message(answer, :authority)) == 0
+    assert length(ExDNS.Records.dns_message(answer, :additional)) == 0
   end
 
 
   test "parent?" do
-    assert Exdns.Resolver.parent?("example.com", "example.com")
+    assert ExDNS.Resolver.parent?("example.com", "example.com")
   end
 
 
   test "type matched records" do
-    soa_rr = Exdns.Records.dns_rr(type: :dns_terms_const.dns_type_soa)
-    a_rr = Exdns.Records.dns_rr(type: :dns_terms_const.dns_type_a)
+    soa_rr = ExDNS.Records.dns_rr(type: :dns_terms_const.dns_type_soa)
+    a_rr = ExDNS.Records.dns_rr(type: :dns_terms_const.dns_type_a)
     records = [soa_rr, a_rr]
-    assert Exdns.Resolver.type_match_records(records, :dns_terms_const.dns_type_soa) == [soa_rr]
-    assert Exdns.Resolver.type_match_records(records, :dns_terms_const.dns_type_any) == [soa_rr, a_rr]
-    assert Exdns.Resolver.type_match_records(records, :dns_terms_const.dns_type_cname) == []
+    assert ExDNS.Resolver.type_match_records(records, :dns_terms_const.dns_type_soa) == [soa_rr]
+    assert ExDNS.Resolver.type_match_records(records, :dns_terms_const.dns_type_any) == [soa_rr, a_rr]
+    assert ExDNS.Resolver.type_match_records(records, :dns_terms_const.dns_type_cname) == []
   end
 
 
@@ -130,10 +130,10 @@ defmodule Exdns.ResolverTest do
 
 
   test "rewrite SOA ttl" do
-    soa_rrdata = Exdns.Records.dns_rrdata_soa(minimum: 60)
-    soa_rr = Exdns.Records.dns_rr(name: "example.com", type: :dns_terms_const.dns_type_soa, ttl: 3600, data: soa_rrdata)
-    message = Exdns.Records.dns_message(authority: [soa_rr])
-    assert Exdns.Resolver.rewrite_soa_ttl(message) |> Exdns.Records.dns_message(:authority) |> List.last |> Exdns.Records.dns_rr(:ttl) == 60
+    soa_rrdata = ExDNS.Records.dns_rrdata_soa(minimum: 60)
+    soa_rr = ExDNS.Records.dns_rr(name: "example.com", type: :dns_terms_const.dns_type_soa, ttl: 3600, data: soa_rrdata)
+    message = ExDNS.Records.dns_message(authority: [soa_rr])
+    assert ExDNS.Resolver.rewrite_soa_ttl(message) |> ExDNS.Records.dns_message(:authority) |> List.last |> ExDNS.Records.dns_rr(:ttl) == 60
   end
 
 
@@ -142,15 +142,15 @@ defmodule Exdns.ResolverTest do
   end
 
   test "requires additional processing with no answers returns the names that are being checked" do
-    assert Exdns.Resolver.requires_additional_processing([], [:name]) == [:name]
+    assert ExDNS.Resolver.requires_additional_processing([], [:name]) == [:name]
   end
 
 
   test "check_dnssec" do
-    opt_rr = Exdns.Records.dns_optrr(dnssec: true)
-    message = Exdns.Records.dns_message(additional: [opt_rr])
-    question = Exdns.Records.dns_query(name: "example.com")
-    assert Exdns.Resolver.check_dnssec(message, :host, question)
+    opt_rr = ExDNS.Records.dns_optrr(dnssec: true)
+    message = ExDNS.Records.dns_message(additional: [opt_rr])
+    question = ExDNS.Records.dns_query(name: "example.com")
+    assert ExDNS.Resolver.check_dnssec(message, :host, question)
   end
 
 end

--- a/test/exdns/server/tcp_server_test.exs
+++ b/test/exdns/server/tcp_server_test.exs
@@ -1,24 +1,24 @@
-defmodule Exdns.Server.TcpServerTest do
+defmodule ExDNS.Server.TCPServerTest do
   use ExUnit.Case, async: false
-  require Exdns.Records
+  require ExDNS.Records
 
   test "server start" do
-    assert Exdns.Server.TcpServer.start_link(:test, :inet, {127,0,0,1}, 12345)
-    Exdns.Server.TcpServer.stop(:test)
+    assert ExDNS.Server.TCPServer.start_link(:test, :inet, {127,0,0,1}, 12345)
+    ExDNS.Server.TCPServer.stop(:test)
   end
 
   test "server start with inet6" do
-    assert Exdns.Server.TcpServer.start_link(:test, :inet, {0,0,0,0,0,0,0,1}, 12345)
-    Exdns.Server.TcpServer.stop(:test)
+    assert ExDNS.Server.TCPServer.start_link(:test, :inet, {0,0,0,0,0,0,0,1}, 12345)
+    ExDNS.Server.TCPServer.stop(:test)
   end
 
   test "handle TCP message" do
-    {:ok, server} = Exdns.Server.TcpServer.start_link(:test, :inet, {127,0,0,1}, 12347)
+    {:ok, server} = ExDNS.Server.TCPServer.start_link(:test, :inet, {127,0,0,1}, 12347)
     {:ok, socket} = :gen_tcp.connect({127,0,0,1}, 12347, [])
-    message = Exdns.Records.dns_message()
-    {false, bin} = Exdns.Encoder.encode_message(message)
+    message = ExDNS.Records.dns_message()
+    {false, bin} = ExDNS.Encoder.encode_message(message)
     assert send(server, {:tcp, socket, bin})
     :gen_tcp.close(socket)
-    Exdns.Server.TcpServer.stop(:test)
+    ExDNS.Server.TCPServer.stop(:test)
   end
 end

--- a/test/exdns/server/udp_server_test.exs
+++ b/test/exdns/server/udp_server_test.exs
@@ -1,54 +1,54 @@
-defmodule Exdns.Server.UdpServerTest do
+defmodule ExDNS.Server.UDPServerTest do
   use ExUnit.Case, async: false
-  require Exdns.Records
+  require ExDNS.Records
 
   @localhost {127,0,0,1}
   @localhost6 {0,0,0,0,0,0,0,1}
 
   test "server start" do 
-    assert Exdns.Server.UdpServer.start_link(:test, :inet, @localhost, 12345)
-    Exdns.Server.UdpServer.stop(:test)
+    assert ExDNS.Server.UDPServer.start_link(:test, :inet, @localhost, 12345)
+    ExDNS.Server.UDPServer.stop(:test)
   end
 
   test "server start with inet6" do
-    assert Exdns.Server.UdpServer.start_link(:test, :inet6, @localhost6, 12345)
-    Exdns.Server.UdpServer.stop(:test)
+    assert ExDNS.Server.UDPServer.start_link(:test, :inet6, @localhost6, 12345)
+    ExDNS.Server.UDPServer.stop(:test)
   end
 
   test "handle timeout message" do
-    {:ok, server} = Exdns.Server.UdpServer.start_link(:test, :inet, @localhost, 12346)
+    {:ok, server} = ExDNS.Server.UDPServer.start_link(:test, :inet, @localhost, 12346)
     assert send(server, :timeout)
-    Exdns.Server.UdpServer.stop(:test)
+    ExDNS.Server.UDPServer.stop(:test)
   end
 
   test "handle UDP message" do
-    {:ok, server} = Exdns.Server.UdpServer.start_link(:test, :inet, {127,0,0,1}, 12347)
+    {:ok, server} = ExDNS.Server.UDPServer.start_link(:test, :inet, {127,0,0,1}, 12347)
     {:ok, socket} = :gen_udp.open(0)
-    message = Exdns.Records.dns_message()
-    {false, bin} = Exdns.Encoder.encode_message(message)
+    message = ExDNS.Records.dns_message()
+    {false, bin} = ExDNS.Encoder.encode_message(message)
     assert send(server, {:udp, socket, :host, :port, bin})
     :gen_udp.close(socket)
-    Exdns.Server.UdpServer.stop(:test)
+    ExDNS.Server.UDPServer.stop(:test)
   end
 
   test "handle request with no workers in the queue" do
     {:ok, socket} = :gen_udp.open(0)
-    message = Exdns.Records.dns_message()
-    {false, bin} = Exdns.Encoder.encode_message(message)
+    message = ExDNS.Records.dns_message()
+    {false, bin} = ExDNS.Encoder.encode_message(message)
     state = %{port: :port, socket: socket, workers: :queue.new()}
-    assert Exdns.Server.UdpServer.handle_request(socket, :host, :port, bin, state)
+    assert ExDNS.Server.UDPServer.handle_request(socket, :host, :port, bin, state)
     :gen_udp.close(socket)
   end
 
   test "handle request with workers in the queue" do
     {:ok, socket} = :gen_udp.open(0)
-    message = Exdns.Records.dns_message()
-    {false, bin} = Exdns.Encoder.encode_message(message)
-    {:ok, worker_pid} = Exdns.Worker.start_link([])
+    message = ExDNS.Records.dns_message()
+    {false, bin} = ExDNS.Encoder.encode_message(message)
+    {:ok, worker_pid} = ExDNS.Worker.start_link([])
     queue = :queue.new()
     workers = :queue.in(worker_pid, queue)
     state = %{port: :port, socket: socket, workers: workers}
-    assert Exdns.Server.UdpServer.handle_request(socket, :host, :port, bin, state)
+    assert ExDNS.Server.UDPServer.handle_request(socket, :host, :port, bin, state)
     :gen_udp.close(socket)
   end
 end

--- a/test/exdns/storage/ets_storage_test.exs
+++ b/test/exdns/storage/ets_storage_test.exs
@@ -1,70 +1,70 @@
-defmodule Exdns.Storage.EtsStorageTest do
+defmodule ExDNS.Storage.EtsStorageTest do
   use ExUnit.Case, async: false
 
   test "create" do
-    assert Exdns.Storage.EtsStorage.create(:test) == :ok
+    assert ExDNS.Storage.EtsStorage.create(:test) == :ok
   end
 
   test "create lookup table" do
-    assert Exdns.Storage.EtsStorage.create(:lookup_table) == :ok
+    assert ExDNS.Storage.EtsStorage.create(:lookup_table) == :ok
   end
 
   test "create schema is not implemented" do
-    assert Exdns.Storage.EtsStorage.create(:schema) == {:error, :not_implemented}
+    assert ExDNS.Storage.EtsStorage.create(:schema) == {:error, :not_implemented}
   end
 
   test "insert" do
-    Exdns.Storage.EtsStorage.create(:test)
-    assert Exdns.Storage.EtsStorage.insert(:test, {:key, :value})
+    ExDNS.Storage.EtsStorage.create(:test)
+    assert ExDNS.Storage.EtsStorage.insert(:test, {:key, :value})
     assert :ets.lookup(:test, :key) == [key: :value]
   end
 
   test "delete table" do
-    Exdns.Storage.EtsStorage.create(:test)
-    assert Exdns.Storage.EtsStorage.delete_table(:test) == :ok
+    ExDNS.Storage.EtsStorage.create(:test)
+    assert ExDNS.Storage.EtsStorage.delete_table(:test) == :ok
   end
 
   test "backup table not implemented" do
-    assert Exdns.Storage.EtsStorage.backup_table(:test) == {:error, :not_implemented}
+    assert ExDNS.Storage.EtsStorage.backup_table(:test) == {:error, :not_implemented}
   end
 
   test "backup tables not implemented" do
-    assert Exdns.Storage.EtsStorage.backup_tables() == {:error, :not_implemented}
+    assert ExDNS.Storage.EtsStorage.backup_tables() == {:error, :not_implemented}
   end
 
   test "select key from table" do
-    Exdns.Storage.EtsStorage.create(:test)
-    assert Exdns.Storage.EtsStorage.select(:test, :key) == []
-    Exdns.Storage.EtsStorage.insert(:test, {:key, :value})
-    assert Exdns.Storage.EtsStorage.select(:test, :key) == [key: :value]
+    ExDNS.Storage.EtsStorage.create(:test)
+    assert ExDNS.Storage.EtsStorage.select(:test, :key) == []
+    ExDNS.Storage.EtsStorage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.EtsStorage.select(:test, :key) == [key: :value]
   end
 
   test "select match spec from table" do
-    Exdns.Storage.EtsStorage.create(:test)
-    assert Exdns.Storage.EtsStorage.select(:test, [{{'$1', '$2'}, [], [{{'$1', '$2'}}]}], :infinite) == []
-    Exdns.Storage.EtsStorage.insert(:test, {:key, :value})
-    assert Exdns.Storage.EtsStorage.select(:test, :key) == [key: :value]
+    ExDNS.Storage.EtsStorage.create(:test)
+    assert ExDNS.Storage.EtsStorage.select(:test, [{{'$1', '$2'}, [], [{{'$1', '$2'}}]}], :infinite) == []
+    ExDNS.Storage.EtsStorage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.EtsStorage.select(:test, :key) == [key: :value]
   end
 
   test "foldl on table" do
-    Exdns.Storage.EtsStorage.create(:test)
-    Exdns.Storage.EtsStorage.insert(:test, {:key1, 1})
-    Exdns.Storage.EtsStorage.insert(:test, {:key2, 1})
-    assert Exdns.Storage.EtsStorage.foldl(fn({_key, val}, acc) -> val + acc end, 0, :test) == 2
+    ExDNS.Storage.EtsStorage.create(:test)
+    ExDNS.Storage.EtsStorage.insert(:test, {:key1, 1})
+    ExDNS.Storage.EtsStorage.insert(:test, {:key2, 1})
+    assert ExDNS.Storage.EtsStorage.foldl(fn({_key, val}, acc) -> val + acc end, 0, :test) == 2
   end
 
   test "empty table" do
-    Exdns.Storage.EtsStorage.create(:test)
-    Exdns.Storage.EtsStorage.insert(:test, {:key, :value})
-    assert Exdns.Storage.EtsStorage.select(:test, :key) == [key: :value]
-    Exdns.Storage.EtsStorage.empty_table(:test)
-    assert Exdns.Storage.EtsStorage.select(:test, :key) == []
+    ExDNS.Storage.EtsStorage.create(:test)
+    ExDNS.Storage.EtsStorage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.EtsStorage.select(:test, :key) == [key: :value]
+    ExDNS.Storage.EtsStorage.empty_table(:test)
+    assert ExDNS.Storage.EtsStorage.select(:test, :key) == []
   end
 
   test "list table" do
-    Exdns.Storage.EtsStorage.create(:test)
-    Exdns.Storage.EtsStorage.insert(:test, {:key, :value})
-    assert Exdns.Storage.EtsStorage.list_table(:test) == [key: :value]
+    ExDNS.Storage.EtsStorage.create(:test)
+    ExDNS.Storage.EtsStorage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.EtsStorage.list_table(:test) == [key: :value]
   end
 end
 

--- a/test/exdns/storage_test.exs
+++ b/test/exdns/storage_test.exs
@@ -1,71 +1,71 @@
-defmodule Exdns.StorageTest do
+defmodule ExDNS.StorageTest do
   use ExUnit.Case, async: false
 
   test "create" do
-    assert Exdns.Storage.create(:test) == :ok
+    assert ExDNS.Storage.create(:test) == :ok
   end
 
   test "insert" do
-    Exdns.Storage.create(:test)
-    assert Exdns.Storage.insert(:test, {:key, :value})
+    ExDNS.Storage.create(:test)
+    assert ExDNS.Storage.insert(:test, {:key, :value})
     assert :ets.lookup(:test, :key) == [key: :value]
   end
 
   test "delete table" do
-    Exdns.Storage.create(:test)
-    assert Exdns.Storage.delete_table(:test) == :ok
+    ExDNS.Storage.create(:test)
+    assert ExDNS.Storage.delete_table(:test) == :ok
   end
 
   test "delete key from table" do
-    Exdns.Storage.create(:test)
-    assert Exdns.Storage.delete(:test, :key) == :ok
-    Exdns.Storage.insert(:test, {:key, :value})
-    assert Exdns.Storage.select(:test, :key) == [key: :value]
-    assert Exdns.Storage.delete(:test, :key) == :ok
-    assert Exdns.Storage.select(:test, :key) == []
+    ExDNS.Storage.create(:test)
+    assert ExDNS.Storage.delete(:test, :key) == :ok
+    ExDNS.Storage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.select(:test, :key) == [key: :value]
+    assert ExDNS.Storage.delete(:test, :key) == :ok
+    assert ExDNS.Storage.select(:test, :key) == []
   end
 
   test "backup table not implemented" do
-    assert Exdns.Storage.backup_table(:test) == {:error, :not_implemented}
+    assert ExDNS.Storage.backup_table(:test) == {:error, :not_implemented}
   end
 
   test "backup tables not implemented" do
-    assert Exdns.Storage.backup_tables() == {:error, :not_implemented}
+    assert ExDNS.Storage.backup_tables() == {:error, :not_implemented}
   end
 
   test "select key from table" do
-    Exdns.Storage.create(:test)
-    assert Exdns.Storage.select(:test, :key) == []
-    Exdns.Storage.insert(:test, {:key, :value})
-    assert Exdns.Storage.select(:test, :key) == [key: :value]
+    ExDNS.Storage.create(:test)
+    assert ExDNS.Storage.select(:test, :key) == []
+    ExDNS.Storage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.select(:test, :key) == [key: :value]
   end
 
   test "select match spec from table" do
-    Exdns.Storage.create(:test)
-    assert Exdns.Storage.select(:test, [{{:"$1", :"$2"}, [], [{{:"$1", :"$2"}}]}], :infinite) == []
-    Exdns.Storage.insert(:test, {:key, :value})
-    assert Exdns.Storage.select(:test, :key) == [key: :value]
+    ExDNS.Storage.create(:test)
+    assert ExDNS.Storage.select(:test, [{{:"$1", :"$2"}, [], [{{:"$1", :"$2"}}]}], :infinite) == []
+    ExDNS.Storage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.select(:test, :key) == [key: :value]
   end
 
   test "foldl on table" do
-    Exdns.Storage.create(:test)
-    Exdns.Storage.insert(:test, {:key1, 1})
-    Exdns.Storage.insert(:test, {:key2, 1})
-    assert Exdns.Storage.foldl(fn({_key, val}, acc) -> val + acc end, 0, :test) == 2
+    ExDNS.Storage.create(:test)
+    ExDNS.Storage.insert(:test, {:key1, 1})
+    ExDNS.Storage.insert(:test, {:key2, 1})
+    assert ExDNS.Storage.foldl(fn({_key, val}, acc) -> val + acc end, 0, :test) == 2
   end
 
   test "empty table" do
-    Exdns.Storage.create(:test)
-    Exdns.Storage.insert(:test, {:key, :value})
-    assert Exdns.Storage.select(:test, :key) == [key: :value]
-    Exdns.Storage.empty_table(:test)
-    assert Exdns.Storage.select(:test, :key) == []
+    ExDNS.Storage.create(:test)
+    ExDNS.Storage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.select(:test, :key) == [key: :value]
+    ExDNS.Storage.empty_table(:test)
+    assert ExDNS.Storage.select(:test, :key) == []
   end
 
   test "list table" do
-    Exdns.Storage.create(:test)
-    Exdns.Storage.insert(:test, {:key, :value})
-    assert Exdns.Storage.list_table(:test) == [key: :value]
+    ExDNS.Storage.create(:test)
+    ExDNS.Storage.insert(:test, {:key, :value})
+    assert ExDNS.Storage.list_table(:test) == [key: :value]
   end
 end
 

--- a/test/exdns/supervisor_test.exs
+++ b/test/exdns/supervisor_test.exs
@@ -1,19 +1,19 @@
-defmodule Exdns.SupervisorTest do
+defmodule ExDNS.SupervisorTest do
   use ExUnit.Case, async: true
 
   test "starts the events worker" do
-    assert List.keymember?(Supervisor.which_children(Exdns.Supervisor), Exdns.Events, 0)
+    assert List.keymember?(Supervisor.which_children(ExDNS.Supervisor), ExDNS.Events, 0)
   end
 
   test "starts the packet cache" do
-    assert List.keymember?(Supervisor.which_children(Exdns.Supervisor), Exdns.PacketCache, 0)
+    assert List.keymember?(Supervisor.which_children(ExDNS.Supervisor), ExDNS.PacketCache, 0)
   end
 
   test "starts the query throttle" do
-    assert List.keymember?(Supervisor.which_children(Exdns.Supervisor), Exdns.QueryThrottle, 0)
+    assert List.keymember?(Supervisor.which_children(ExDNS.Supervisor), ExDNS.QueryThrottle, 0)
   end
 
   test "starts the handler registry" do
-    assert List.keymember?(Supervisor.which_children(Exdns.Supervisor), Exdns.Handler.Registry, 0)
+    assert List.keymember?(Supervisor.which_children(ExDNS.Supervisor), ExDNS.Handler.Registry, 0)
   end
 end

--- a/test/exdns/txt_test.exs
+++ b/test/exdns/txt_test.exs
@@ -1,35 +1,35 @@
-defmodule Exdns.TxtTest do
+defmodule ExDNS.TxtTest do
   use ExUnit.Case, async: true
 
   test "parse empty string" do
-    assert Exdns.Txt.parse("") == []
+    assert ExDNS.Txt.parse("") == []
   end
 
   test "parse simple string" do
-    assert Exdns.Txt.parse("test") == ["test"]
+    assert ExDNS.Txt.parse("test") == ["test"]
   end
 
   test "parse long string" do
-    assert Exdns.Txt.parse(String.duplicate("x", 270)) == [String.duplicate("x", 255), String.duplicate("x", 15)]
+    assert ExDNS.Txt.parse(String.duplicate("x", 270)) == [String.duplicate("x", 255), String.duplicate("x", 15)]
   end
 
   test "parse string with escaped quotes" do
-    assert Exdns.Txt.parse("\"test\" \"test\"") == ["test","test"]
+    assert ExDNS.Txt.parse("\"test\" \"test\"") == ["test","test"]
   end
 
   test "parse escape character by itself" do
-    assert Exdns.Txt.parse("\\") == ["\\"]
+    assert ExDNS.Txt.parse("\\") == ["\\"]
   end
 
   test "parse escaped slash followed by a semi-colon" do
-    assert Exdns.Txt.parse("test\\;") == ["test\\;"]
+    assert ExDNS.Txt.parse("test\\;") == ["test\\;"]
   end
 
   test "parse escaped slash as final character" do
-    assert Exdns.Txt.parse("test\\") == ["test\\"]
+    assert ExDNS.Txt.parse("test\\") == ["test\\"]
   end
 
   test "parse quoted string with escaped quote" do
-    assert Exdns.Txt.parse("test\"") == ["test\""]
+    assert ExDNS.Txt.parse("test\"") == ["test\""]
   end
 end

--- a/test/exdns/worker_test.exs
+++ b/test/exdns/worker_test.exs
@@ -1,26 +1,26 @@
-defmodule Exdns.WorkerTest do
+defmodule ExDNS.WorkerTest do
   use ExUnit.Case, async: false
-  require Exdns.Records
+  require ExDNS.Records
 
   setup do
-    {:ok, worker} = Exdns.Worker.start_link([])
+    {:ok, worker} = ExDNS.Worker.start_link([])
     {:ok, worker: worker}
   end
 
   test "handle UDP query" do
-    message = Exdns.Records.dns_message()
+    message = ExDNS.Records.dns_message()
 
     {:ok, socket} = :gen_udp.open(0)
-    {false, bin} = Exdns.Encoder.encode_message(message)
-    assert Exdns.Worker.handle_udp_dns_query(socket, :host, :port, bin)
+    {false, bin} = ExDNS.Encoder.encode_message(message)
+    assert ExDNS.Worker.handle_udp_dns_query(socket, :host, :port, bin)
     :gen_udp.close(socket)
   end
 
   test "handle TCP query" do
-    message = Exdns.Records.dns_message()
+    message = ExDNS.Records.dns_message()
     {:ok, socket} = :gen_tcp.listen(0, [])
-    {false, bin} = Exdns.Encoder.encode_message(message)
-    assert Exdns.Worker.handle_tcp_dns_query(socket, <<byte_size(bin)>> <> bin)
+    {false, bin} = ExDNS.Encoder.encode_message(message)
+    assert ExDNS.Worker.handle_tcp_dns_query(socket, <<byte_size(bin)>> <> bin)
     :gen_tcp.close(socket)
   end
 end

--- a/test/exdns/zone/cache_test.exs
+++ b/test/exdns/zone/cache_test.exs
@@ -1,83 +1,83 @@
-defmodule Exdns.Zone.CacheTest do
+defmodule ExDNS.Zone.CacheTest do
   use ExUnit.Case, async: false
-  require Exdns.Records
+  require ExDNS.Records
 
   setup do
     name = "example.com"
 
-    soa_record = Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa, data: Exdns.Records.dns_rrdata_soa())
-    ns_record = Exdns.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_ns, data: Exdns.Records.dns_rrdata_ns(dname: "ns1.example.com"))
-    cname_record = Exdns.Records.dns_rr(name: "www.#{name}", type: :dns_terms_const.dns_type_cname, data: Exdns.Records.dns_rrdata_cname(dname: "something.com"))
+    soa_record = ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_soa, data: ExDNS.Records.dns_rrdata_soa())
+    ns_record = ExDNS.Records.dns_rr(name: name, type: :dns_terms_const.dns_type_ns, data: ExDNS.Records.dns_rrdata_ns(dname: "ns1.example.com"))
+    cname_record = ExDNS.Records.dns_rr(name: "www.#{name}", type: :dns_terms_const.dns_type_cname, data: ExDNS.Records.dns_rrdata_cname(dname: "something.com"))
 
     records = [soa_record, ns_record, cname_record]
-    zone = %Exdns.Zone{name: name, authority: soa_record, records: records, records_by_name: Exdns.Zone.Parser.build_named_index(records)}
+    zone = %ExDNS.Zone{name: name, authority: soa_record, records: records, records_by_name: ExDNS.Zone.Parser.build_named_index(records)}
 
-    Exdns.Zone.Cache.put_zone(name, zone)
+    ExDNS.Zone.Cache.put_zone(name, zone)
 
     {:ok, %{:zone => zone, delegation: ns_record, authority: soa_record, cname_record: cname_record}}
   end
 
   test "find zone not found" do
-    assert Exdns.Zone.Cache.find_zone("notfound.com") == {:error, :not_authoritative}
+    assert ExDNS.Zone.Cache.find_zone("notfound.com") == {:error, :not_authoritative}
   end
 
   test "find zone", %{zone: zone} do
-    assert Exdns.Zone.Cache.find_zone(zone.name) == %{zone | records: [], records_by_name: :trimmed}
+    assert ExDNS.Zone.Cache.find_zone(zone.name) == %{zone | records: [], records_by_name: :trimmed}
   end
 
   test "get zone", %{zone: zone} do
-    assert Exdns.Zone.Cache.get_zone(zone.name) == {:ok, %{zone | records: [], records_by_name: :trimmed}}
+    assert ExDNS.Zone.Cache.get_zone(zone.name) == {:ok, %{zone | records: [], records_by_name: :trimmed}}
   end
 
   test "get authority for name", %{zone: zone} do
-    {:ok,authority} = Exdns.Zone.Cache.get_authority(zone.name)
-    assert Exdns.Records.dns_rr(authority, :type) == :dns_terms_const.dns_type_soa
+    {:ok,authority} = ExDNS.Zone.Cache.get_authority(zone.name)
+    assert ExDNS.Records.dns_rr(authority, :type) == :dns_terms_const.dns_type_soa
   end
 
   test "get authority for message", %{zone: zone} do
-    question = Exdns.Records.dns_query(name: zone.name, type: :dns_terms_const.dns_type_a)
-    message = Exdns.Records.dns_message(questions: [question])
-    {:ok, authority} = Exdns.Zone.Cache.get_authority(message)
-    assert Exdns.Records.dns_rr(authority, :type) == :dns_terms_const.dns_type_soa
+    question = ExDNS.Records.dns_query(name: zone.name, type: :dns_terms_const.dns_type_a)
+    message = ExDNS.Records.dns_message(questions: [question])
+    {:ok, authority} = ExDNS.Zone.Cache.get_authority(message)
+    assert ExDNS.Records.dns_rr(authority, :type) == :dns_terms_const.dns_type_soa
   end
 
 
   test "get records by name", %{zone: zone, cname_record: cname_record} do
-    assert Exdns.Zone.Cache.get_records_by_name("example.com") == zone.records -- [cname_record]
-    assert Exdns.Zone.Cache.get_records_by_name("www.example.com") == [cname_record]
+    assert ExDNS.Zone.Cache.get_records_by_name("example.com") == zone.records -- [cname_record]
+    assert ExDNS.Zone.Cache.get_records_by_name("www.example.com") == [cname_record]
   end
 
 
   test "in_zone?" do
-    assert Exdns.Zone.Cache.in_zone?("example.com")
+    assert ExDNS.Zone.Cache.in_zone?("example.com")
   end
 
 
   test "get delegations returns delegation records", %{delegation: ns_record} do
-    assert Exdns.Zone.Cache.get_delegations("example.com") == []
-    assert Exdns.Zone.Cache.get_delegations("ns1.example.com") == [ns_record]
+    assert ExDNS.Zone.Cache.get_delegations("example.com") == []
+    assert ExDNS.Zone.Cache.get_delegations("ns1.example.com") == [ns_record]
   end
 
 
   test "find zone in cache exact name", %{zone: zone} do
-    assert Exdns.Zone.Cache.find_zone_in_cache("example.com") == {:ok, zone}
+    assert ExDNS.Zone.Cache.find_zone_in_cache("example.com") == {:ok, zone}
   end
 
   test "find zone in cache subdomain", %{zone: zone} do
-    assert Exdns.Zone.Cache.find_zone_in_cache("fewf.afdaf.example.com") == {:ok, zone}
+    assert ExDNS.Zone.Cache.find_zone_in_cache("fewf.afdaf.example.com") == {:ok, zone}
   end
 
   test "find zone in cache not found" do
-    assert Exdns.Zone.Cache.find_zone_in_cache("notfound.com") == {:error, :zone_not_found}
+    assert ExDNS.Zone.Cache.find_zone_in_cache("notfound.com") == {:error, :zone_not_found}
   end
 
   test "normalize name" do
-    assert Exdns.Zone.Cache.normalize_name("eXaMpLe.CoM") == "example.com"
+    assert ExDNS.Zone.Cache.normalize_name("eXaMpLe.CoM") == "example.com"
   end
 
   test "fallback to wildcard zone when configured" do
     Application.put_env(:exdns, :wildcard_fallback, true)
-    {:ok, _zone} = Exdns.Zone.Cache.find_zone_in_cache("notfound.com")
+    {:ok, _zone} = ExDNS.Zone.Cache.find_zone_in_cache("notfound.com")
     Application.put_env(:exdns, :wildcard_fallback, false)
   end
 end

--- a/test/exdns/zone/loader_test.exs
+++ b/test/exdns/zone/loader_test.exs
@@ -1,4 +1,4 @@
-defmodule Exdns.Zone.LoaderTest do
+defmodule ExDNS.Zone.LoaderTest do
   use ExUnit.Case, async: false
 
 

--- a/test/exdns/zone/parser_test.exs
+++ b/test/exdns/zone/parser_test.exs
@@ -1,6 +1,6 @@
-defmodule Exdns.Zone.ParserTest do
+defmodule ExDNS.Zone.ParserTest do
   use ExUnit.Case, async: true
-  require Exdns.Records
+  require ExDNS.Records
 
   # Zone translation
 
@@ -9,12 +9,12 @@ defmodule Exdns.Zone.ParserTest do
     soa_record = %{"name" => "example.com", "type" => "SOA", "ttl" => 3600, "data" => %{
         "mname" => "ns1.example.com", "rname" => "admin.example.com", "serial" => 1, "refresh" => 2, "retry" => 3, "expire" => 4, "minimum" => 5}}
     records = [soa_record]
-    zone = Exdns.Zone.Parser.json_to_zone(%{"name" => name, "records" => records})
+    zone = ExDNS.Zone.Parser.json_to_zone(%{"name" => name, "records" => records})
     assert zone.name == name
     assert zone.version == ""
-    assert zone.authority == Exdns.Zone.Parser.json_record_to_rr(soa_record)
-    assert zone.records == Enum.map(records, &Exdns.Zone.Parser.json_record_to_rr/1)
-    assert zone.records_by_name == %{name => Enum.map(records, &Exdns.Zone.Parser.json_record_to_rr/1)}
+    assert zone.authority == ExDNS.Zone.Parser.json_record_to_rr(soa_record)
+    assert zone.records == Enum.map(records, &ExDNS.Zone.Parser.json_record_to_rr/1)
+    assert zone.records_by_name == %{name => Enum.map(records, &ExDNS.Zone.Parser.json_record_to_rr/1)}
   end
 
   test "json to zone with SHA" do
@@ -22,18 +22,18 @@ defmodule Exdns.Zone.ParserTest do
     soa_record = %{"name" => "example.com", "type" => "SOA", "ttl" => 3600, "data" => %{
         "mname" => "ns1.example.com", "rname" => "admin.example.com", "serial" => 1, "refresh" => 2, "retry" => 3, "expire" => 4, "minimum" => 5}}
     records = [soa_record]
-    zone = Exdns.Zone.Parser.json_to_zone(%{"name" => name, "sha" => sha, "records" => records})
+    zone = ExDNS.Zone.Parser.json_to_zone(%{"name" => name, "sha" => sha, "records" => records})
     assert zone.name == name
     assert zone.version == sha
-    assert zone.authority == Exdns.Zone.Parser.json_record_to_rr(soa_record)
-    assert zone.records == Enum.map(records, &Exdns.Zone.Parser.json_record_to_rr/1)
-    assert zone.records_by_name == %{name => Enum.map(records, &Exdns.Zone.Parser.json_record_to_rr/1)}
+    assert zone.authority == ExDNS.Zone.Parser.json_record_to_rr(soa_record)
+    assert zone.records == Enum.map(records, &ExDNS.Zone.Parser.json_record_to_rr/1)
+    assert zone.records_by_name == %{name => Enum.map(records, &ExDNS.Zone.Parser.json_record_to_rr/1)}
   end
 
   # Context
 
   test "apply context options with no context" do
-    assert Exdns.Zone.Parser.apply_context_options(%{}) == :pass
+    assert ExDNS.Zone.Parser.apply_context_options(%{}) == :pass
   end
 
   # Record translation
@@ -41,124 +41,124 @@ defmodule Exdns.Zone.ParserTest do
   test "json record to A RR" do
     name = "example.com"; ttl = 3600
     data = %{"ip" => "1.2.3.4"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "A", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_a(:ip)) == {1,2,3,4}
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "A", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_a(:ip)) == {1,2,3,4}
   end
 
   test "json record to AAAA RR" do
     name = "example.com"; ttl = 3600
     data = %{"ip" => "::1"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "AAAA", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_aaaa(:ip)) == {0,0,0,0,0,0,0,1}
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "AAAA", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_aaaa(:ip)) == {0,0,0,0,0,0,0,1}
   end
 
   test "json record to CNAME RR" do
     name = "example.com"; ttl = 3600
     data = %{"dname" => "somesite.com"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "CNAME", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_cname(:dname)) == "somesite.com"
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "CNAME", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_cname(:dname)) == "somesite.com"
   end
 
   test "json record to HINFO RR" do
     name = "example.com"; ttl = 3600
     data = %{"cpu" => "i386", "os" => "linux"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "HINFO", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_hinfo(:cpu)) == "i386"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_hinfo(:os)) == "linux"
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "HINFO", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_hinfo(:cpu)) == "i386"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_hinfo(:os)) == "linux"
   end
 
   test "json record to MX RR" do
     name = "example.com"; ttl = 3600
     data = %{"exchange" => "mx1.mail.com", "preference" => "20"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "MX", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_mx(:exchange)) == "mx1.mail.com"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_mx(:preference)) == "20"
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "MX", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_mx(:exchange)) == "mx1.mail.com"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_mx(:preference)) == "20"
   end
 
   test "json record to NAPTR RR" do
     name = "example.com"; ttl = 3600
     data = %{"order" => "1", "preference" => "20", "flags" => "u", "services" => "tcp", "regexp" => "", "replacement" => ""}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "NAPTR", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_naptr(:order)) == "1"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_naptr(:preference)) == "20"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_naptr(:flags)) == "u"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_naptr(:services)) == "tcp"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_naptr(:regexp)) == ""
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_naptr(:replacement)) == ""
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "NAPTR", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_naptr(:order)) == "1"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_naptr(:preference)) == "20"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_naptr(:flags)) == "u"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_naptr(:services)) == "tcp"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_naptr(:regexp)) == ""
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_naptr(:replacement)) == ""
   end
 
   test "json record to NS RR" do
     name = "example.com"; ttl = 3600
     data = %{"dname" => "ns1.example.com"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "NS", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_ns(:dname)) == "ns1.example.com"
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "NS", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_ns(:dname)) == "ns1.example.com"
   end
 
   test "json record to RP RR" do
     name = "example.com"; ttl = 3600
     data = %{"mbox" => "hostmaster.example.com", "txt" => "rp.example.com"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "RP", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_rp(:mbox)) == "hostmaster.example.com"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_rp(:txt)) == "rp.example.com"
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "RP", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_rp(:mbox)) == "hostmaster.example.com"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_rp(:txt)) == "rp.example.com"
   end
 
   test "json record to SOA RR" do
     name = "example.com"; ttl = 3600
     data = %{"mname" => "ns1.example.com", "rname" => "admin.example.com", "serial" => 1, "refresh" => 2, "retry" => 3, "expire" => 4, "minimum" => 5}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SOA", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_soa(:mname)) == "ns1.example.com"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_soa(:rname)) == "admin.example.com"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_soa(:serial)) == 1
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_soa(:refresh)) == 2
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_soa(:retry)) == 3
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_soa(:expire)) == 4
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_soa(:minimum)) == 5
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SOA", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_soa(:mname)) == "ns1.example.com"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_soa(:rname)) == "admin.example.com"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_soa(:serial)) == 1
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_soa(:refresh)) == 2
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_soa(:retry)) == 3
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_soa(:expire)) == 4
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_soa(:minimum)) == 5
   end
 
   test "json record to SPF RR" do
     name = "example.com"; ttl = 3600
     data = %{"spf" => "v=spf1 -all"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SPF", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_spf(:spf)) == "v=spf1 -all"
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SPF", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_spf(:spf)) == "v=spf1 -all"
   end
 
   test "json record to SRV RR" do
     name = "example.com"; ttl = 3600
     data = %{"priority" => "10", "weight" => "20", "port" => "5050", "target" => "x.example.com"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SRV", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_srv(:priority)) == "10"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_srv(:weight)) == "20"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_srv(:port)) == "5050"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_srv(:target)) == "x.example.com"
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SRV", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_srv(:priority)) == "10"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_srv(:weight)) == "20"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_srv(:port)) == "5050"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_srv(:target)) == "x.example.com"
   end
 
   test "json record to SSHFP RR" do
     name = "example.com"; ttl = 3600
     data = %{"alg" => "2", "fp_type" => "1", "fp" => "123456789abcdef67890123456789abcdef67890"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SSHFP", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_sshfp(:alg)) == "2"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_sshfp(:fp_type)) == "1"
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_sshfp(:fp)) == <<18, 52, 86, 120, 154, 188, 222, 246, 120, 144, 18, 52, 86, 120, 154, 188, 222, 246, 120, 144>>
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SSHFP", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_sshfp(:alg)) == "2"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_sshfp(:fp_type)) == "1"
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_sshfp(:fp)) == <<18, 52, 86, 120, 154, 188, 222, 246, 120, 144, 18, 52, 86, 120, 154, 188, 222, 246, 120, 144>>
   end
 
   test "json record to TXT RR" do
     name = "example.com"; ttl = 3600
     data = %{"txt" => "this is some text"}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "TXT", "ttl" => ttl, "data" => data})
-    assert (Exdns.Records.dns_rr(rr, :data) |> Exdns.Records.dns_rrdata_txt(:txt)) == ["this is some text"]
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "TXT", "ttl" => ttl, "data" => data})
+    assert (ExDNS.Records.dns_rr(rr, :data) |> ExDNS.Records.dns_rrdata_txt(:txt)) == ["this is some text"]
   end
 
   # Named index
 
   test "build empty named index" do
-    index = Exdns.Zone.Parser.build_named_index([])
+    index = ExDNS.Zone.Parser.build_named_index([])
     assert Map.keys(index) == []
   end
   test "build named index" do
     name = "example.com"; ttl = 3600
     data = %{"mname" => "ns1.example.com", "rname" => "admin.example.com", "serial" => 1, "refresh" => 2, "retry" => 3, "expire" => 4, "minimum" => 5}
-    rr = Exdns.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SOA", "ttl" => ttl, "data" => data})
-    index = Exdns.Zone.Parser.build_named_index([rr])
+    rr = ExDNS.Zone.Parser.json_record_to_rr(%{"name" => name, "type" => "SOA", "ttl" => ttl, "data" => data})
+    index = ExDNS.Zone.Parser.build_named_index([rr])
     assert index[name] != nil
   end
 

--- a/test/exdns/zone/registry_test.exs
+++ b/test/exdns/zone/registry_test.exs
@@ -1,15 +1,15 @@
-defmodule Exdns.Zone.RegistryTest do
+defmodule ExDNS.Zone.RegistryTest do
   use ExUnit.Case, async: true
 
   test "register module" do
-    assert Exdns.Zone.Registry.register(:mod)
-    assert Exdns.Zone.Registry.get_all == [:mod]
-    Exdns.Zone.Registry.clear
+    assert ExDNS.Zone.Registry.register(:mod)
+    assert ExDNS.Zone.Registry.get_all == [:mod]
+    ExDNS.Zone.Registry.clear
   end
 
   test "register modules" do
-    assert Exdns.Zone.Registry.register([:mod1, :mod2])
-    assert Exdns.Zone.Registry.get_all == [:mod1, :mod2]
-    Exdns.Zone.Registry.clear
+    assert ExDNS.Zone.Registry.register([:mod1, :mod2])
+    assert ExDNS.Zone.Registry.get_all == [:mod1, :mod2]
+    ExDNS.Zone.Registry.clear
   end
 end


### PR DESCRIPTION
- [x] Turn `Tcp`, `Udp` and `Exdns` into `TCP`, `UDP` and `ExDNS`.
- [x] Raise the bar for the Mixfile. Elixir 1.6 is now the minimal version
- [x] Use the new supervisor syntax.
- [x] The `ExDNS` module now only holds functions, the supervision and application entry point is the standard `ExDND.Application`.